### PR TITLE
Fix package versions

### DIFF
--- a/packages/confirm/snap.manifest.json
+++ b/packages/confirm/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0-development",
+  "version": "0.0.4",
   "proposedName": "MetaMask Confirm Test Snap",
   "description": "An MetaMask Test Snap that uses the snap_confirm permission",
   "repository": {

--- a/packages/error/snap.manifest.json
+++ b/packages/error/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0-development",
+  "version": "0.0.4",
   "proposedName": "MetaMask Error Test Snap",
   "description": "An MetaMask Test Snap that throws an error",
   "repository": {


### PR DESCRIPTION
Running `yarn build` at the repo root changed the versions in `snap.manifest.json`.