### PR TITLE
Fix Snap manifest versions

### DIFF
--- a/packages/bip44/snap.manifest.json
+++ b/packages/bip44/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.9",
+  "version": "0.1.3",
   "description": "An example Snap that signs messages using BLS.",
   "proposedName": "@metamask/test-snap-bip44",
   "repository": {

--- a/packages/confirm/snap.manifest.json
+++ b/packages/confirm/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.9",
+  "version": "0.1.3",
   "proposedName": "MetaMask Confirm Test Snap",
   "description": "An MetaMask Test Snap that uses the snap_confirm permission",
   "repository": {

--- a/packages/error/snap.manifest.json
+++ b/packages/error/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.9",
+  "version": "0.1.3",
   "proposedName": "MetaMask Error Test Snap",
   "description": "An MetaMask Test Snap that throws an error",
   "repository": {


### PR DESCRIPTION
We have a missing build step and the manifest versions weren't updated.