### PR TITLE
Fix BIP-44 snap publishConfig

### DIFF
--- a/packages/bip44/package.json
+++ b/packages/bip44/package.json
@@ -8,6 +8,10 @@
     "type": "git",
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "license": "ISC",
   "files": [
     "dist/",


### PR DESCRIPTION
The BIP-44 snap lacked the correct `publishConfig` in its `package.json`.