### PR TITLE
Update site changelog

### DIFF
--- a/packages/site/CHANGELOG.md
+++ b/packages/site/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0]
 ### Changed
-- No changes this release.
+- Request specific versions for snaps in production ([#37](https://github.com/MetaMask/test-snaps/pull/37))
+  - When the site is deployed to GitHub pages at a path ending in its SemVer version, connecting to a snap will request the version corresponding to the URL.
+  - For example, if the URL is `metamask.github.io/test-snaps/0.3.0`, version `0.3.0` will be requested.
+  - This change will be backported to previous GitHub pages releases of this package.
 
 ## [0.2.0]
 ### Changed


### PR DESCRIPTION
Updates the `site` changelog to include #37, which needs to be included in the upcoming `0.3.0` release of this package, which has yet to be published.