### PR TITLE
Update BIP-44 test snap and fix BIP-32 manifest

### DIFF
--- a/packages/bip32/snap.manifest.json
+++ b/packages/bip32/snap.manifest.json
@@ -17,31 +17,24 @@
     }
   },
   "initialPermissions": {
-    "snap_getBip32Entropy": {
-      "caveats": [
-        {
-          "type": "permittedDerivationPaths",
-          "value": [
-            {
-              "path": [
-                "m",
-                "44'",
-                "0'"
-              ],
-              "curve": "secp256k1"
-            },
-            {
-              "path": [
-                "m",
-                "44'",
-                "0'"
-              ],
-              "curve": "ed25519"
-            }
-          ]
-        }
-      ]
-    }
+    "snap_getBip32Entropy": [
+      {
+        "path": [
+          "m",
+          "44'",
+          "0'"
+        ],
+        "curve": "secp256k1"
+      },
+      {
+        "path": [
+          "m",
+          "44'",
+          "0'"
+        ],
+        "curve": "ed25519"
+      }
+    ]
   },
   "manifestVersion": "0.1"
 }

--- a/packages/bip44/snap.manifest.json
+++ b/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "mBfFhvXuhsetdYPcI9YJH8hBa/o76fnGDPMgufOr/M0=",
+    "shasum": "4HAokYjaC6liSKG0l8Qmn2bUAadL5l3e86EdvzOZ0q0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -18,7 +18,14 @@
   },
   "initialPermissions": {
     "snap_confirm": {},
-    "snap_getBip44Entropy_1": {}
+    "snap_getBip44Entropy": [
+      {
+        "coinType": 1
+      },
+      {
+        "coinType": 2
+      }
+    ]
   },
   "manifestVersion": "0.1"
 }

--- a/packages/bip44/snap.manifest.json
+++ b/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "2bsxhn8z0TruL+a9ye7HgEpfvdlTGsZY/dLDZ6b+6SU=",
+    "shasum": "gZ6c9lanQUm5an45m6e/UfA1rOZWAkgKagsGxqG7L8w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/bip44/snap.manifest.json
+++ b/packages/bip44/snap.manifest.json
@@ -21,9 +21,6 @@
     "snap_getBip44Entropy": [
       {
         "coinType": 1
-      },
-      {
-        "coinType": 2
       }
     ]
   },

--- a/packages/bip44/snap.manifest.json
+++ b/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "4HAokYjaC6liSKG0l8Qmn2bUAadL5l3e86EdvzOZ0q0=",
+    "shasum": "2bsxhn8z0TruL+a9ye7HgEpfvdlTGsZY/dLDZ6b+6SU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/bip44/src/index.ts
+++ b/packages/bip44/src/index.ts
@@ -74,7 +74,9 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
         params: [
           {
             prompt: 'BLS signature request',
-            textAreaContent: `Do you want to BLS sign ${data} with ${pubKey}?`,
+            textAreaContent: `Do you want to BLS sign ${data} with ${nobleOutputToHexString(
+              pubKey,
+            )}?`,
           },
         ],
       });

--- a/packages/bip44/src/index.ts
+++ b/packages/bip44/src/index.ts
@@ -6,8 +6,6 @@ import {
 } from '@metamask/key-tree';
 import { OnRpcRequestHandler } from '@metamask/snap-types';
 
-let encoder: TextEncoder;
-
 interface GetAccountParams {
   coinType: number;
   [key: string]: unknown;
@@ -83,7 +81,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       if (!approved) {
         throw ethErrors.provider.userRejectedRequest();
       }
-      const newLocal = await sign(encoder.encode(data), privateKey);
+      const newLocal = await sign(new TextEncoder().encode(data), privateKey);
       return nobleOutputToHexString(newLocal);
     }
 

--- a/packages/bip44/src/index.ts
+++ b/packages/bip44/src/index.ts
@@ -6,14 +6,38 @@ import {
 } from '@metamask/key-tree';
 import { OnRpcRequestHandler } from '@metamask/snap-types';
 
-let PRIVATE_KEY: Uint8Array;
 let encoder: TextEncoder;
 
-export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
-  if (!PRIVATE_KEY) {
-    await initialize();
-  }
+interface GetAccountParams {
+  coinType: number;
+  [key: string]: unknown;
+}
 
+/**
+ * Get a private key for the specified coin type.
+ *
+ * @param coinType - The coin type to get the private key for.
+ * @returns The private key as Uint8Array.
+ */
+const getPrivateKey = async (coinType = 1) => {
+  const coinTypeNode = (await wallet.request({
+    method: 'snap_getBip44Entropy',
+    params: {
+      coinType,
+    },
+  })) as JsonBIP44CoinTypeNode;
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return (
+    await deriveBIP44AddressKey(coinTypeNode, {
+      account: 0,
+      change: 0,
+      address_index: 0,
+    })
+  ).privateKeyBuffer!;
+};
+
+export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   /**
    * Converts ugly output from @noble/bls12-381 to readable hex.
    *
@@ -29,11 +53,16 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   }
 
   switch (request.method) {
-    case 'getAccount':
-      return nobleOutputToHexString(getPublicKey(PRIVATE_KEY));
+    case 'getAccount': {
+      const params = request.params as GetAccountParams;
+      return nobleOutputToHexString(
+        getPublicKey(await getPrivateKey(params?.coinType)),
+      );
+    }
 
     case 'signMessage': {
-      const pubKey = getPublicKey(PRIVATE_KEY);
+      const privateKey = await getPrivateKey();
+      const pubKey = getPublicKey(privateKey);
       const data = (request.params as string[])[0];
 
       if (!data || typeof data !== 'string') {
@@ -54,7 +83,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       if (!approved) {
         throw ethErrors.provider.userRejectedRequest();
       }
-      const newLocal = await sign(encoder.encode(data), PRIVATE_KEY);
+      const newLocal = await sign(encoder.encode(data), privateKey);
       return nobleOutputToHexString(newLocal);
     }
 
@@ -64,25 +93,3 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       });
   }
 };
-
-/**
- * Calls `snap_getBip44Entropy_1` and sets {@link PRIVATE_KEY} to an address key
- * derived from the received `coin_type` entropy.
- */
-async function initialize() {
-  encoder = new TextEncoder();
-
-  const coinTypeNode = (await wallet.request({
-    method: 'snap_getBip44Entropy_1',
-  })) as JsonBIP44CoinTypeNode;
-
-  PRIVATE_KEY =
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    (
-      await deriveBIP44AddressKey(coinTypeNode, {
-        account: 0,
-        change: 0,
-        address_index: 0,
-      })
-    ).privateKeyBuffer!;
-}

--- a/packages/site/src/index.html
+++ b/packages/site/src/index.html
@@ -127,6 +127,12 @@
               <p class="info-text alert alert-secondary">
                 <span id="bip44Result"></span>
               </p>
+              <button
+                id="sendInvalidBip44"
+                class="btn btn-primary btn-med btn-block mb-3 btn-wide"
+              >
+                Send Invalid Test to BIP-44 Snap
+              </button>
               <br />
               <input id="bip44SignMessage" placeholder="message" />
               <br />
@@ -396,6 +402,7 @@
     snapId3.value = 'local:http://localhost:8083';
     const connectBip44Button = document.querySelector('#connectBip44');
     const sendBip44Button = document.querySelector('#sendBip44');
+    const sendBip44InvalidButton = document.querySelector('#sendInvalidBip44');
     const bip44Result = document.querySelector('#bip44Result');
 
     const bip44SignMessage = document.querySelector('#bip44SignMessage');
@@ -407,7 +414,8 @@
     );
 
     connectBip44Button.addEventListener('click', connectBip44);
-    sendBip44Button.addEventListener('click', sendBip44);
+    sendBip44Button.addEventListener('click', getSendBip44());
+    sendBip44InvalidButton.addEventListener('click', getSendBip44({ coinType: 3 }));
     sendBip44MessageButton.addEventListener('click', sendBip44Message);
 
     async function connectBip44() {
@@ -421,21 +429,24 @@
       });
     }
 
-    async function sendBip44() {
-      try {
-        const result = await ethereum.request({
-          method: 'wallet_invokeSnap',
-          params: [
-            snapId3.value,
-            {
-              method: 'getAccount',
-            },
-          ],
-        });
-        bip44Result.innerHTML = `Public key: ${JSON.stringify(result)}`;
-      } catch (err) {
-        console.error(err);
-        alert('Problem happened: ' + err.message || err);
+    function getSendBip44(params = undefined) {
+      return async function sendBip44() {
+        try {
+          const result = await ethereum.request({
+            method: 'wallet_invokeSnap',
+            params: [
+              snapId3.value,
+              {
+                method: 'getAccount',
+                params
+              },
+            ],
+          });
+          bip44Result.innerHTML = `Public key: ${JSON.stringify(result)}`;
+        } catch (err) {
+          console.error(err);
+          alert('Problem happened: ' + err.message || err);
+        }
       }
     }
 


### PR DESCRIPTION
This updates the BIP-44 test snap to use `snap_getBip44Entropy` instead of the deprecated `snap_getBip44Entropy_*`. It also fixes the manifest of the BIP-32, which was changed to a more simple format.