### PR TITLE
Fix `clean` npm script in each package

### DIFF
--- a/packages/bip32/package.json
+++ b/packages/bip32/package.json
@@ -23,7 +23,7 @@
     "build": "mm-snap build --eval false",
     "build:clean": "yarn clean && yarn build",
     "build:dev": "yarn build",
-    "clean": "rimraf dist/*",
+    "clean": "rimraf 'dist/*'",
     "serve": "mm-snap serve",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch",

--- a/packages/bip44/package.json
+++ b/packages/bip44/package.json
@@ -23,7 +23,7 @@
     "build": "mm-snap build --eval false",
     "build:clean": "yarn clean && yarn build",
     "build:dev": "yarn build",
-    "clean": "rimraf dist/*",
+    "clean": "rimraf 'dist/*'",
     "serve": "mm-snap serve",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch",

--- a/packages/confirm/package.json
+++ b/packages/confirm/package.json
@@ -22,7 +22,7 @@
     "build": "mm-snap build --eval false",
     "build:dev": "yarn build",
     "build:clean": "yarn clean && yarn build",
-    "clean": "rimraf dist/*",
+    "clean": "rimraf 'dist/*'",
     "serve": "mm-snap serve",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch",

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -25,7 +25,7 @@
     "build": "mm-snap build --eval false",
     "build:clean": "yarn clean && yarn build",
     "build:dev": "yarn build",
-    "clean": "rimraf dist/*",
+    "clean": "rimraf 'dist/*'",
     "serve": "mm-snap serve",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch",

--- a/packages/manageState/package.json
+++ b/packages/manageState/package.json
@@ -22,7 +22,7 @@
     "build": "mm-snap build --eval false",
     "build:dev": "yarn build",
     "build:clean": "yarn clean && yarn build",
-    "clean": "rimraf dist/*",
+    "clean": "rimraf 'dist/*'",
     "serve": "mm-snap serve",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch",

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -22,7 +22,7 @@
     "build": "mm-snap build --eval false",
     "build:dev": "yarn build",
     "build:clean": "yarn clean && yarn build",
-    "clean": "rimraf dist/*",
+    "clean": "rimraf 'dist/*'",
     "serve": "mm-snap serve",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -12,7 +12,7 @@
     "build": "node scripts/build.js prod",
     "build:clean": "yarn clean && yarn build",
     "build:dev": "node scripts/build.js dev",
-    "clean": "rimraf dist/*",
+    "clean": "rimraf 'dist/*'",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' '**/*.html' --single-quote --ignore-path ../../.gitignore --no-error-on-unmatched-pattern",
     "lint": "yarn lint:eslint && yarn lint:misc --check",


### PR DESCRIPTION
The `clean` npm script in each repository was failing when the `dist` directory was empty. This is because the script was using an unquoted asterisk, which was being expanded by the shell into nothing, causing the script to fail.

Instead the path being removed has now been quoted, ensuring it gets expanded by `rimraf` directly instead. `rimraf` is fine with the pattern resolving to nothing, so the command now succeeds for the empty case.