### PR TITLE
Fix `publish:all` script

### DIFF
--- a/scripts/publish-all.sh
+++ b/scripts/publish-all.sh
@@ -26,4 +26,4 @@ if [[ -z $OTP ]]; then
   exit 1
 fi
 
-yarn workspaces run publish "$OTP"
+yarn workspaces foreach run publish "$OTP"


### PR DESCRIPTION
The `publish:all` script uses the Yarn v1 syntax for running a command in each packge. This fails in Yarn v3. It has been updated to use the new `foreach` syntax.