### PR TITLE
Use root `.prettierignore` for all packages

### DIFF
--- a/packages/bip32/package.json
+++ b/packages/bip32/package.json
@@ -28,7 +28,7 @@
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch",
     "lint:eslint": "eslint . --cache --ext js,ts",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --single-quote --ignore-path .gitignore --no-error-on-unmatched-pattern",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --single-quote --ignore-path ../../.prettierignore --no-error-on-unmatched-pattern",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",

--- a/packages/bip44/package.json
+++ b/packages/bip44/package.json
@@ -28,7 +28,7 @@
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch",
     "lint:eslint": "eslint . --cache --ext js,ts",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --single-quote --ignore-path .gitignore --no-error-on-unmatched-pattern",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --single-quote --ignore-path ../../.prettierignore --no-error-on-unmatched-pattern",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",

--- a/packages/confirm/package.json
+++ b/packages/confirm/package.json
@@ -27,7 +27,7 @@
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch",
     "lint:eslint": "eslint . --cache --ext js,ts",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --single-quote --ignore-path ../../.gitignore --no-error-on-unmatched-pattern",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --single-quote --ignore-path ../../.prettierignore --no-error-on-unmatched-pattern",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -30,7 +30,7 @@
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch",
     "lint:eslint": "eslint . --cache --ext js,ts",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --single-quote --ignore-path ../../.gitignore --no-error-on-unmatched-pattern",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --single-quote --ignore-path ../../.prettierignore --no-error-on-unmatched-pattern",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",

--- a/packages/manageState/package.json
+++ b/packages/manageState/package.json
@@ -27,7 +27,7 @@
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch",
     "lint:eslint": "eslint . --cache --ext js,ts",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --single-quote --ignore-path ../../.gitignore --no-error-on-unmatched-pattern",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --single-quote --ignore-path ../../.prettierignore --no-error-on-unmatched-pattern",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -27,7 +27,7 @@
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch",
     "lint:eslint": "eslint . --cache --ext js,ts",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --single-quote --ignore-path ../../.gitignore --no-error-on-unmatched-pattern",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --single-quote --ignore-path ../../.prettierignore --no-error-on-unmatched-pattern",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -14,7 +14,7 @@
     "build:dev": "node scripts/build.js dev",
     "clean": "rimraf 'dist/*'",
     "lint:eslint": "eslint . --cache --ext js,ts",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' '**/*.html' --single-quote --ignore-path ../../.gitignore --no-error-on-unmatched-pattern",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' '**/*.html' --single-quote --ignore-path ../../.prettierignore --no-error-on-unmatched-pattern",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",


### PR DESCRIPTION
There was an issue with Prettier failing when running `yarn lint` inside `packages/bip32`, which was not caught when running it inside the root folder. To fix this, I've updated all packages to use the root `.prettierignore`.

The problem is that Prettier generates different output than the Snaps CLI, so as a workaround we have to ignore `snap.manifest.json`. Otherwise this would result in CI issues, since the working folder is not "clean".