### PR TITLE
Rework BIP32 test snap to add message signing

### DIFF
--- a/packages/bip32/package.json
+++ b/packages/bip32/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@metamask/key-tree": "^4.0.0",
     "@metamask/snap-types": "^0.16.0",
+    "@metamask/utils": "^3.1.0",
     "@noble/ed25519": "^1.7.1",
     "eth-rpc-errors": "^4.0.3"
   },

--- a/packages/bip32/package.json
+++ b/packages/bip32/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@metamask/key-tree": "^4.0.0",
     "@metamask/snap-types": "^0.16.0",
+    "@noble/ed25519": "^1.7.1",
     "eth-rpc-errors": "^4.0.3"
   },
   "devDependencies": {

--- a/packages/bip32/snap.manifest.json
+++ b/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "y7nx8mKQy4CguUgnSlMQPuBDAAzcwfeGc9eLG9wQp70=",
+    "shasum": "+Evicd30SdByffBp2O5WK2DSyQd1DwKBAF457MOGhXI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/bip32/snap.manifest.json
+++ b/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "+PeoWiVnlraFPGWnMPVHwIRbo/8u/MwsXRj8rO63hCc=",
+    "shasum": "y7nx8mKQy4CguUgnSlMQPuBDAAzcwfeGc9eLG9wQp70=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -17,6 +17,7 @@
     }
   },
   "initialPermissions": {
+    "snap_confirm": {},
     "snap_getBip32Entropy": [
       {
         "path": [

--- a/packages/bip32/snap.manifest.json
+++ b/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "+Evicd30SdByffBp2O5WK2DSyQd1DwKBAF457MOGhXI=",
+    "shasum": "wGKNU/UtSwYK8i9rumMeNx+TijU0039FjfdAIl58IYM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/bip32/src/index.ts
+++ b/packages/bip32/src/index.ts
@@ -2,6 +2,7 @@ import { ethErrors } from 'eth-rpc-errors';
 import { JsonSLIP10Node, SLIP10Node } from '@metamask/key-tree';
 import { OnRpcRequestHandler } from '@metamask/snap-types';
 import { sign } from '@noble/ed25519';
+import { bytesToHex } from '@metamask/utils';
 
 interface GetAccountParams {
   path: string;
@@ -31,11 +32,6 @@ const getPublicKey = async (params: GetAccountParams): Promise<string> => {
     params,
   })) as string;
 };
-
-const toHex = (array: Uint8Array) =>
-  `0x${Object.values(array)
-    .map((num) => num.toString(16))
-    .join('')}`;
 
 export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   switch (request.method) {
@@ -71,7 +67,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
         new TextEncoder().encode(message),
         node.privateKey as string,
       );
-      return toHex(signed);
+      return bytesToHex(signed);
     }
 
     default:

--- a/packages/bip32/src/index.ts
+++ b/packages/bip32/src/index.ts
@@ -2,7 +2,7 @@ import { ethErrors } from 'eth-rpc-errors';
 import { JsonSLIP10Node, SLIP10Node } from '@metamask/key-tree';
 import { OnRpcRequestHandler } from '@metamask/snap-types';
 import { sign } from '@noble/ed25519';
-import { bytesToHex } from '@metamask/utils';
+import { add0x, assert, bytesToHex } from '@metamask/utils';
 
 interface GetAccountParams {
   path: string;
@@ -54,7 +54,9 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
         params: [
           {
             prompt: 'Signature request',
-            textAreaContent: `Do you want to ed25519 sign ${message} with 0x${node.publicKey}?`,
+            textAreaContent: `Do you want to ed25519 sign ${message} with ${add0x(
+              node.publicKey,
+            )}?`,
           },
         ],
       });
@@ -62,10 +64,10 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       if (!approved) {
         throw ethErrors.provider.userRejectedRequest();
       }
-
+      assert(node.privateKey);
       const signed = await sign(
         new TextEncoder().encode(message),
-        node.privateKey as string,
+        node.privateKey,
       );
       return bytesToHex(signed);
     }

--- a/packages/bip32/src/index.ts
+++ b/packages/bip32/src/index.ts
@@ -1,6 +1,7 @@
 import { ethErrors } from 'eth-rpc-errors';
 import { JsonSLIP10Node, SLIP10Node } from '@metamask/key-tree';
 import { OnRpcRequestHandler } from '@metamask/snap-types';
+import { sign } from '@noble/ed25519';
 
 interface GetAccountParams {
   path: string;
@@ -9,14 +10,19 @@ interface GetAccountParams {
   [key: string]: unknown;
 }
 
-const getPrivateKey = async (params: GetAccountParams): Promise<string> => {
+interface SignMessageParams extends GetAccountParams {
+  message: string;
+
+  [key: string]: unknown;
+}
+
+const getSLIP10Node = async (params: GetAccountParams): Promise<SLIP10Node> => {
   const json = (await wallet.request({
     method: 'snap_getBip32Entropy',
     params,
   })) as JsonSLIP10Node;
 
-  const node = await SLIP10Node.fromJSON(json);
-  return node.privateKey as string;
+  return SLIP10Node.fromJSON(json);
 };
 
 const getPublicKey = async (params: GetAccountParams): Promise<string> => {
@@ -26,13 +32,47 @@ const getPublicKey = async (params: GetAccountParams): Promise<string> => {
   })) as string;
 };
 
+const toHex = (array: Uint8Array) =>
+  `0x${Object.values(array)
+    .map((num) => num.toString(16))
+    .join('')}`;
+
 export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   switch (request.method) {
-    case 'getAccount':
-      return await getPrivateKey(request.params as GetAccountParams);
-
     case 'getPublicKey':
       return await getPublicKey(request.params as GetAccountParams);
+
+    case 'signMessage': {
+      const { message, ...params } = request.params as SignMessageParams;
+
+      if (!message || typeof message !== 'string') {
+        throw ethErrors.rpc.invalidParams({
+          message: `Invalid signature data: "${message}".`,
+        });
+      }
+
+      const node = await getSLIP10Node(params);
+
+      const approved = await wallet.request({
+        method: 'snap_confirm',
+        params: [
+          {
+            prompt: 'Signature request',
+            textAreaContent: `Do you want to ed25519 sign ${message} with 0x${node.publicKey}?`,
+          },
+        ],
+      });
+
+      if (!approved) {
+        throw ethErrors.provider.userRejectedRequest();
+      }
+
+      const signed = await sign(
+        new TextEncoder().encode(message),
+        node.privateKey as string,
+      );
+      return toHex(signed);
+    }
 
     default:
       throw ethErrors.rpc.methodNotFound({

--- a/packages/bip44/package.json
+++ b/packages/bip44/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@metamask/key-tree": "^4.0.0",
     "@metamask/snap-types": "^0.16.0",
+    "@metamask/utils": "^3.1.0",
     "@noble/bls12-381": "^1.2.0",
     "eth-rpc-errors": "^4.0.3"
   },

--- a/packages/bip44/snap.manifest.json
+++ b/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "6RchPrkjImrvduCtz599WTghuIQY8OfKg2Yc8hl/pCg=",
+    "shasum": "sNcuvDinSDfR/n0w6k9ZRc6K4+Wx79yEXauZslrmwB4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/bip44/snap.manifest.json
+++ b/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "gZ6c9lanQUm5an45m6e/UfA1rOZWAkgKagsGxqG7L8w=",
+    "shasum": "6RchPrkjImrvduCtz599WTghuIQY8OfKg2Yc8hl/pCg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/site/src/index.html
+++ b/packages/site/src/index.html
@@ -260,6 +260,9 @@
               >
                 Connect BIP-32 Snap
               </button>
+              <input id="bip32SignMessage" placeholder="message" />
+              <br />
+              <br />
               <button
                 id="sendBip32Secp256k1"
                 class="btn btn-primary btn-med btn-block mb-3 btn-wide"
@@ -677,6 +680,7 @@
     const snapId6 = document.querySelector('#snapId6');
     snapId6.value = 'local:http://localhost:8086';
     const connectBip32Button = document.querySelector('#connectBip32');
+    const bip32SignMessage = document.querySelector('#bip32SignMessage');
     const sendBip32Secp256k1Button = document.querySelector('#sendBip32Secp256k1');
     const sendBip32Ed25519Button = document.querySelector('#sendBip32Ed25519');
     const sendBip32PublicKeyButton = document.querySelector('#sendBip32PublicKey');
@@ -713,12 +717,12 @@
             params: [
               snapId6.value,
               {
-                method: 'getAccount',
-                params: { path, curve },
+                method: 'signMessage',
+                params: { path, curve, message: bip32SignMessage.value },
               },
             ],
           });
-          target.innerHTML = `Private key: ${JSON.stringify(result)}`;
+          target.innerHTML = `Signature: ${JSON.stringify(result)}`;
         } catch (err) {
           console.error(err);
           alert('Problem happened: ' + err.message || err);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2596,6 +2596,7 @@ __metadata:
     "@metamask/key-tree": ^4.0.0
     "@metamask/snap-types": ^0.16.0
     "@metamask/snaps-cli": ^0.16.0
+    "@metamask/utils": ^3.1.0
     "@noble/ed25519": ^1.7.1
     "@types/jest": ^26.0.13
     "@typescript-eslint/eslint-plugin": ^5.19.0
@@ -2628,6 +2629,7 @@ __metadata:
     "@metamask/key-tree": ^4.0.0
     "@metamask/snap-types": ^0.16.0
     "@metamask/snaps-cli": ^0.16.0
+    "@metamask/utils": ^3.1.0
     "@noble/bls12-381": ^1.2.0
     "@types/jest": ^26.0.13
     "@typescript-eslint/eslint-plugin": ^5.19.0
@@ -2777,6 +2779,18 @@ __metadata:
   dependencies:
     fast-deep-equal: ^3.1.3
   checksum: 50970fe28cbf98fbc34fb4f69d9bc90f5db94929c69ab532f57b48f42163ea77fb080ab31854efd984361c3e29e67831a78d94d1211ac3bcc6b9557769c73127
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@metamask/utils@npm:3.1.0"
+  dependencies:
+    "@types/debug": ^4.1.7
+    debug: ^4.3.4
+    fast-deep-equal: ^3.1.3
+    superstruct: ^0.16.5
+  checksum: 6d2c3dab762554d783b49411dd5e285457642d821bc81eee56d2d47af0923bdbc297b7970c71a45dfa870122d00e5613a51c7433ce604d6a1b64ee292d95df0d
   languageName: node
   linkType: hard
 
@@ -3016,6 +3030,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/debug@npm:^4.1.7":
+  version: 4.1.7
+  resolution: "@types/debug@npm:4.1.7"
+  dependencies:
+    "@types/ms": "*"
+  checksum: 0a7b89d8ed72526858f0b61c6fd81f477853e8c4415bb97f48b1b5545248d2ae389931680b94b393b993a7cfe893537a200647d93defe6d87159b96812305adc
+  languageName: node
+  linkType: hard
+
 "@types/deep-freeze-strict@npm:^1.1.0":
   version: 1.1.0
   resolution: "@types/deep-freeze-strict@npm:1.1.0"
@@ -3101,6 +3124,13 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: e60b153664572116dfea673c5bda7778dbff150498f44f998e34b5886d8afc47f16799280e4b6e241c0472aef1bc36add771c569c68fc5125fc2ae519a3eb9ac
+  languageName: node
+  linkType: hard
+
+"@types/ms@npm:*":
+  version: 0.7.31
+  resolution: "@types/ms@npm:0.7.31"
+  checksum: daadd354aedde024cce6f5aa873fefe7b71b22cd0e28632a69e8b677aeb48ae8caa1c60e5919bb781df040d116b01cb4316335167a3fc0ef6a63fa3614c0f6da
   languageName: node
   linkType: hard
 
@@ -11866,6 +11896,13 @@ __metadata:
   dependencies:
     minimist: ^1.1.0
   checksum: 8359df72e9a2d03c35702ba58e49cac04daae8f27dff26837e12687c7d10cb800a036fd33fdc5eb0e8c24fb25d804f657fe8bde18dd3dd6ec7dab8eff7aac27e
+  languageName: node
+  linkType: hard
+
+"superstruct@npm:^0.16.5":
+  version: 0.16.5
+  resolution: "superstruct@npm:0.16.5"
+  checksum: 9f843c38695b584a605ae9b028629de18a85bd0dca0e9449b4ab98bb7b9ac3d82599870acbab9fbd2ee454c6b187af7e61562e252dfadabd974191ab4ab2e3ce
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2596,6 +2596,7 @@ __metadata:
     "@metamask/key-tree": ^4.0.0
     "@metamask/snap-types": ^0.16.0
     "@metamask/snaps-cli": ^0.16.0
+    "@noble/ed25519": ^1.7.1
     "@types/jest": ^26.0.13
     "@typescript-eslint/eslint-plugin": ^5.19.0
     "@typescript-eslint/parser": ^5.19.0
@@ -2801,10 +2802,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/ed25519@npm:^1.6.0":
-  version: 1.6.1
-  resolution: "@noble/ed25519@npm:1.6.1"
-  checksum: 4bf9177549e8e93464cdc6740990973ca5d3447e68dd608aff3d7380b12d1007eb77e38b4806d74b580ba4eee7408f036331dc0387319fa49d64d4d62c648aaf
+"@noble/ed25519@npm:^1.6.0, @noble/ed25519@npm:^1.7.1":
+  version: 1.7.1
+  resolution: "@noble/ed25519@npm:1.7.1"
+  checksum: b8e50306ac70f5cecc349111997e72e897b47a28d406b96cf95d0ebe7cbdefb8380d26117d7847d94102281db200aa3a494e520f9fc12e2f292e0762cb0fa333
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reworks the BIP-32 snap to remove `getAccount` and add `signMessage`. It gets the private key as before, but now uses it to sign an input message with `ed25519`.