### PR TITLE
Update descriptions in test-snap manifests

### DIFF
--- a/packages/confirm/snap.manifest.json
+++ b/packages/confirm/snap.manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "3.0.2",
   "proposedName": "MetaMask Confirm Test Snap",
-  "description": "An MetaMask Test Snap that uses the snap_confirm permission",
+  "description": "A MetaMask Test Snap that uses the snap_confirm permission",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/test-snaps.git"

--- a/packages/error/snap.manifest.json
+++ b/packages/error/snap.manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "3.0.2",
   "proposedName": "MetaMask Error Test Snap",
-  "description": "An MetaMask Test Snap that throws an error",
+  "description": "A MetaMask Test Snap that throws an error",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/test-snaps.git"

--- a/packages/manageState/snap.manifest.json
+++ b/packages/manageState/snap.manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "3.0.2",
   "proposedName": "MetaMask manageState Test Snap",
-  "description": "An MetaMask Test Snap that uses the manageState permission",
+  "description": "A MetaMask Test Snap that uses the manageState permission",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/test-snaps.git"

--- a/packages/notification/snap.manifest.json
+++ b/packages/notification/snap.manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "3.0.2",
   "proposedName": "MetaMask Notification Test Snap",
-  "description": "An MetaMask Test Snap that uses the notification permission",
+  "description": "A MetaMask Test Snap that uses the notification permission",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/test-snaps.git"


### PR DESCRIPTION
this fixes grammatical errors in 4 test snaps.
Fixes #74 