### PR TITLE
[HOTFIX] Fix names of called snaps

### DIFF
--- a/packages/site/src/features/bip-32-snap/BIP32.tsx
+++ b/packages/site/src/features/bip-32-snap/BIP32.tsx
@@ -3,7 +3,7 @@ import { Snap } from '../../components';
 import { SignMessage } from './SignMessage';
 import { PublicKey } from './PublicKey';
 
-export const BIP_32_SNAP_ID = 'npm:@metamask/test-snap-bip-32';
+export const BIP_32_SNAP_ID = 'npm:@metamask/test-snap-bip32';
 export const BIP_32_PORT = 8006;
 
 export const BIP32: FunctionComponent = () => {

--- a/packages/site/src/features/bip-44-snap/BIP44.tsx
+++ b/packages/site/src/features/bip-44-snap/BIP44.tsx
@@ -5,7 +5,7 @@ import { useInvokeMutation } from '../../api';
 import { getSnapId } from '../../utils/id';
 import { SignMessage } from './SignMessage';
 
-export const BIP_44_SNAP_ID = 'npm:@metamask/test-snap-bip-44';
+export const BIP_44_SNAP_ID = 'npm:@metamask/test-snap-bip44';
 export const BIP_44_PORT = 8003;
 
 export const BIP44: FunctionComponent = () => {

--- a/packages/site/src/features/manage-state-snap/ManageState.tsx
+++ b/packages/site/src/features/manage-state-snap/ManageState.tsx
@@ -5,7 +5,7 @@ import { getSnapId, useInstalled } from '../../utils';
 import { SendData } from './SendData';
 import { ClearData } from './ClearData';
 
-export const MANAGE_STATE_ID = 'npm:@metamask/test-snap-manage-state';
+export const MANAGE_STATE_ID = 'npm:@metamask/test-snap-managestate';
 export const MANAGE_STATE_PORT = 8004;
 
 export const MANAGE_STATE_ACTUAL_ID = getSnapId(


### PR DESCRIPTION
Snap names were inadvertantly renamed to be mismatched with existing test snaps on npm

test-snap-bip32
test-snap-bip44
test-snap-managestate

