### PR TITLE
Update release and package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
   },
   "homepage": "https://metamask.github.io/test-snaps/",
   "scripts": {
-    "setup": "yarn install",
-    "prepublishOnly": "yarn build && yarn lint && yarn test",
     "publish:all": "./scripts/publish-all.sh",
     "build": "yarn workspaces foreach --parallel --verbose run build",
     "build:clean": "yarn clean && yarn build",

--- a/packages/bip32/package.json
+++ b/packages/bip32/package.json
@@ -19,7 +19,6 @@
     "snap.manifest.json"
   ],
   "scripts": {
-    "setup": "yarn install",
     "build": "mm-snap build --eval false",
     "build:clean": "yarn clean && yarn build",
     "build:dev": "yarn build",
@@ -32,8 +31,7 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",
-    "prepublishOnly": "yarn build && yarn lint && yarn test",
-    "publish": "../../scripts/publish-package.sh"
+    "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
     "@metamask/key-tree": "^6.0.0",

--- a/packages/bip44/package.json
+++ b/packages/bip44/package.json
@@ -19,7 +19,6 @@
     "snap.manifest.json"
   ],
   "scripts": {
-    "setup": "yarn install",
     "build": "mm-snap build --eval false",
     "build:clean": "yarn clean && yarn build",
     "build:dev": "yarn build",
@@ -32,8 +31,7 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",
-    "prepublishOnly": "yarn build && yarn lint && yarn test",
-    "publish": "../../scripts/publish-package.sh"
+    "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
     "@metamask/key-tree": "^6.0.0",

--- a/packages/confirm/package.json
+++ b/packages/confirm/package.json
@@ -18,7 +18,6 @@
     "images/icon.svg"
   ],
   "scripts": {
-    "setup": "yarn install",
     "build": "mm-snap build --eval false",
     "build:dev": "yarn build",
     "build:clean": "yarn clean && yarn build",
@@ -31,8 +30,7 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",
-    "prepublishOnly": "yarn build && yarn lint && yarn test",
-    "publish": "../../scripts/publish-package.sh"
+    "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
     "@metamask/snap-types": "^0.23.0"

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -21,7 +21,6 @@
     "images/icon.svg"
   ],
   "scripts": {
-    "setup": "yarn install",
     "build": "mm-snap build --eval false",
     "build:clean": "yarn clean && yarn build",
     "build:dev": "yarn build",
@@ -34,8 +33,7 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",
-    "prepublishOnly": "yarn build && yarn lint && yarn test",
-    "publish": "../../scripts/publish-package.sh"
+    "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
     "@metamask/snap-types": "^0.23.0"

--- a/packages/manageState/package.json
+++ b/packages/manageState/package.json
@@ -18,7 +18,6 @@
     "images/icon.svg"
   ],
   "scripts": {
-    "setup": "yarn install",
     "build": "mm-snap build --eval false",
     "build:dev": "yarn build",
     "build:clean": "yarn clean && yarn build",
@@ -31,8 +30,7 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",
-    "prepublishOnly": "yarn build && yarn lint && yarn test",
-    "publish": "../../scripts/publish-package.sh"
+    "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
     "@metamask/snap-types": "^0.23.0"

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -18,7 +18,6 @@
     "images/icon.svg"
   ],
   "scripts": {
-    "setup": "yarn install",
     "build": "mm-snap build --eval false",
     "build:dev": "yarn build",
     "build:clean": "yarn clean && yarn build",
@@ -31,8 +30,7 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",
-    "prepublishOnly": "yarn build && yarn lint && yarn test",
-    "publish": "../../scripts/publish-package.sh"
+    "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
     "@metamask/snap-types": "^0.23.0"

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -8,7 +8,6 @@
   },
   "private": true,
   "scripts": {
-    "setup": "yarn install",
     "start": "gatsby develop -p 8080",
     "build": "gatsby build --prefix-paths",
     "build:clean": "yarn clean && yarn build",
@@ -18,7 +17,7 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",
-    "publish": "echo N/A"
+    "publish:package": "echo N/A"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^2.5.0",

--- a/scripts/publish-all.sh
+++ b/scripts/publish-all.sh
@@ -9,12 +9,13 @@ set -o pipefail
 # git working tree remains cleans, then asks for an npm 2FA code and publishes
 # all packages.
 
-yarn setup
+yarn install
 yarn build:clean
 yarn lint
+yarn test
 
 if ! git diff --exit-code; then
-  echo "Working tree dirty after building"
+  echo "Working tree dirty"
   exit 1
 fi
 
@@ -26,4 +27,4 @@ if [[ -z $OTP ]]; then
   exit 1
 fi
 
-yarn workspaces foreach run publish "$OTP"
+yarn workspaces foreach run publish:package "$OTP"


### PR DESCRIPTION
Updates the release and package scripts to resolve errors during `yarn publish:all` flow. With the previous implementation, `npm` would attempt to publish each package twice, seemingly because we defined a package script named `publish`. This script has been renamed to `publish:package` so as to not collide with the `npm publish` command.

As part of this change, the `prepublishOnly` script has been removed for each package as it performs redundant work when packages are published via the `publish:all` command. This is potentially ~unsafe in cases were single packages are published directly, but I don't foresee us doing so until we migrate to a different publishing flow entirely (ref: #66).

Finally, the deprecated `setup` package script is also removed.