### PR TITLE
Use BIP32 snap for update snap test

### DIFF
--- a/packages/site/src/features/update-snap/Update.tsx
+++ b/packages/site/src/features/update-snap/Update.tsx
@@ -7,9 +7,9 @@ import {
   useInvokeMutation,
 } from '../../api';
 
-const UPDATE_SNAP_ID = 'npm:@metamask/test-snap-confirm';
-const UPDATE_SNAP_OLD_VERSION = '1.0.0';
-const UPDATE_SNAP_NEW_VERSION = '2.0.0';
+const UPDATE_SNAP_ID = 'npm:@metamask/test-snap-bip32';
+const UPDATE_SNAP_OLD_VERSION = '4.0.1';
+const UPDATE_SNAP_NEW_VERSION = '4.0.2';
 
 export const Update: FunctionComponent = () => {
   const [installSnap, { isLoading }] = useInstallSnapMutation();


### PR DESCRIPTION
Use BIP32 snap for the update test instead of confirm, because we've seen bugs happen with the update flow with snaps that have more advanced permissions that include caveats.