### PR TITLE
Add JSON-RPC endowment test snap

### DIFF
--- a/packages/bip32/snap.manifest.json
+++ b/packages/bip32/snap.manifest.json
@@ -17,6 +17,9 @@
     }
   },
   "initialPermissions": {
+    "endowment:rpc": {
+      "dapps": true
+    },
     "snap_confirm": {},
     "snap_getBip32Entropy": [
       {

--- a/packages/confirm/snap.manifest.json
+++ b/packages/confirm/snap.manifest.json
@@ -18,6 +18,9 @@
     }
   },
   "initialPermissions": {
+    "endowment:rpc": {
+      "dapps": true
+    },
     "snap_confirm": {}
   },
   "manifestVersion": "0.1"

--- a/packages/error/snap.manifest.json
+++ b/packages/error/snap.manifest.json
@@ -18,6 +18,9 @@
     }
   },
   "initialPermissions": {
+    "endowment:rpc": {
+      "dapps": true
+    },
     "snap_confirm": {}
   },
   "manifestVersion": "0.1"

--- a/packages/manageState/snap.manifest.json
+++ b/packages/manageState/snap.manifest.json
@@ -18,6 +18,9 @@
     }
   },
   "initialPermissions": {
+    "endowment:rpc": {
+      "dapps": true
+    },
     "snap_manageState": {}
   },
   "manifestVersion": "0.1"

--- a/packages/notification/snap.manifest.json
+++ b/packages/notification/snap.manifest.json
@@ -18,6 +18,9 @@
     }
   },
   "initialPermissions": {
+    "endowment:rpc": {
+      "dapps": true
+    },
     "snap_notify": {}
   },
   "manifestVersion": "0.1"

--- a/packages/rpc/.eslintrc.js
+++ b/packages/rpc/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  root: true,
+
+  extends: ['../../.eslintrc.js'],
+
+  ignorePatterns: ['!.eslintrc.js', 'dist/', 'build/'],
+};

--- a/packages/rpc/CHANGELOG.md
+++ b/packages/rpc/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/MetaMask/test-snaps/

--- a/packages/rpc/README.md
+++ b/packages/rpc/README.md
@@ -1,0 +1,3 @@
+# JSON-RPC Permissions Test Snap
+
+This Snap is used to test the JSON-RPC permission.

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@metamask/test-snap-rpc",
+  "version": "4.1.2",
+  "description": "MetaMask JSON-RPC Permissions Test Snap",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/test-snaps.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "ISC",
+  "files": [
+    "dist/",
+    "images/icon.svg",
+    "snap.manifest.json"
+  ],
+  "scripts": {
+    "build": "mm-snap build --eval false",
+    "build:clean": "yarn clean && yarn build",
+    "build:dev": "yarn build",
+    "clean": "rimraf 'dist/*'",
+    "start": "mm-snap watch",
+    "test": "jest --passWithNoTests",
+    "test:watch": "jest --watch",
+    "lint:eslint": "eslint . --cache --ext js,ts",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --single-quote --ignore-path ../../.prettierignore --no-error-on-unmatched-pattern",
+    "lint": "yarn lint:eslint && yarn lint:misc --check",
+    "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
+    "lint:changelog": "yarn auto-changelog validate"
+  },
+  "dependencies": {
+    "@metamask/key-tree": "^6.0.0",
+    "@metamask/snaps-types": "^0.24.1",
+    "@metamask/utils": "^3.3.0",
+    "@noble/ed25519": "^1.7.1",
+    "@noble/secp256k1": "^1.7.0",
+    "eth-rpc-errors": "^4.0.3"
+  },
+  "devDependencies": {
+    "@metamask/auto-changelog": "^2.5.0",
+    "@metamask/eslint-config": "^6.0.0",
+    "@metamask/eslint-config-jest": "^6.0.0",
+    "@metamask/eslint-config-nodejs": "^6.0.0",
+    "@metamask/eslint-config-typescript": "^6.0.0",
+    "@metamask/snaps-cli": "^0.24.1",
+    "@types/jest": "^26.0.13",
+    "@typescript-eslint/eslint-plugin": "^5.19.0",
+    "@typescript-eslint/parser": "^5.19.0",
+    "eslint": "^7.30.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-import": "^2.23.4",
+    "eslint-plugin-jest": "^24.4.0",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^3.4.0",
+    "jest": "^26.4.2",
+    "prettier": "^2.2.1",
+    "rimraf": "^3.0.2",
+    "ts-jest": "^26.3.0",
+    "ts-node": "^9.0.0",
+    "typescript": "^4.4.0"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  }
+}

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -33,12 +33,7 @@
     "lint:changelog": "yarn auto-changelog validate"
   },
   "dependencies": {
-    "@metamask/key-tree": "^6.0.0",
-    "@metamask/snaps-types": "^0.24.1",
-    "@metamask/utils": "^3.3.0",
-    "@noble/ed25519": "^1.7.1",
-    "@noble/secp256k1": "^1.7.0",
-    "eth-rpc-errors": "^4.0.3"
+    "@metamask/snaps-types": "^0.24.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^2.5.0",

--- a/packages/rpc/snap.config.js
+++ b/packages/rpc/snap.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  cliOptions: {
+    port: 8007,
+    src: './src/index.ts',
+  },
+};

--- a/packages/rpc/snap.manifest.json
+++ b/packages/rpc/snap.manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "4.1.2",
-  "description": "An example Snap that derives keys using BIP-32.",
-  "proposedName": "@metamask/test-snap-bip32",
+  "description": "An example snap to test JSON-RPC permissions.",
+  "proposedName": "@metamask/test-snap-rpc",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/test-snaps.git"

--- a/packages/rpc/snap.manifest.json
+++ b/packages/rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "fPRWbqFKKUvjVdfoSwvJt8pimXG4mhJGsxU+i4nyh6g=",
+    "shasum": "g7T1uCi+lZNdSo85d4ixmkC9DsoBDe99Lv1wLRu/Iz8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/rpc/snap.manifest.json
+++ b/packages/rpc/snap.manifest.json
@@ -1,17 +1,17 @@
 {
   "version": "4.1.2",
-  "description": "An example Snap that signs messages using BLS.",
-  "proposedName": "@metamask/test-snap-bip44",
+  "description": "An example Snap that derives keys using BIP-32.",
+  "proposedName": "@metamask/test-snap-bip32",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "YhLTlRGoLz+WfRxinPPju2A7I0daNcwTNU5NOPfHKrA=",
+    "shasum": "fPRWbqFKKUvjVdfoSwvJt8pimXG4mhJGsxU+i4nyh6g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
-        "packageName": "@metamask/test-snap-bip44",
+        "packageName": "@metamask/test-snap-rpc",
         "registry": "https://registry.npmjs.org"
       }
     }
@@ -19,13 +19,7 @@
   "initialPermissions": {
     "endowment:rpc": {
       "dapps": true
-    },
-    "snap_confirm": {},
-    "snap_getBip44Entropy": [
-      {
-        "coinType": 1
-      }
-    ]
+    }
   },
   "manifestVersion": "0.1"
 }

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -1,0 +1,43 @@
+import { OnRpcRequestHandler } from '@metamask/snaps-types';
+
+const OTHER_SNAP_ID = 'npm:@metamask/test-snap-bip32';
+
+/**
+ * Request access to {@link OTHER_SNAP_ID} if it is not already connected.
+ */
+const requestSnap = async () => {
+  const snaps = (await snap.request({ method: 'wallet_getSnaps' })) as Record<
+    string,
+    unknown
+  >;
+
+  if (!snaps[OTHER_SNAP_ID]) {
+    await snap.request({
+      method: 'wallet_requestSnaps',
+      params: {
+        [OTHER_SNAP_ID]: {},
+      },
+    });
+  }
+};
+
+export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
+  switch (request.method) {
+    case 'send': {
+      await requestSnap();
+
+      return snap.request({
+        method: 'wallet_invokeSnap',
+        params: {
+          snapId: OTHER_SNAP_ID,
+          request: {
+            method: 'getPublicKey',
+          },
+        },
+      });
+    }
+
+    default:
+      throw new Error('Method not found.');
+  }
+};

--- a/packages/rpc/tsconfig.json
+++ b/packages/rpc/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["DOM", "ES2020"],
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "exclude": ["./src/**/*.test.ts", "./build"],
+  "include": ["./src/**/*.ts"]
+}

--- a/packages/site/src/features/rpc-snap/Rpc.tsx
+++ b/packages/site/src/features/rpc-snap/Rpc.tsx
@@ -1,0 +1,44 @@
+import { FunctionComponent } from 'react';
+import { Button } from 'react-bootstrap';
+import { Result, Snap } from '../../components';
+import { useInvokeMutation } from '../../api';
+import { getSnapId } from '../../utils';
+
+const RPC_SNAP_ID = 'npm:@metamask/test-snap-rpc';
+const RPC_SNAP_PORT = 8007;
+
+export const Rpc: FunctionComponent = () => {
+  const [invokeSnap, { isLoading, data, error }] = useInvokeMutation();
+
+  const handleSubmit = () => {
+    invokeSnap({
+      snapId: getSnapId(RPC_SNAP_ID, RPC_SNAP_PORT),
+      method: 'send',
+    });
+  };
+
+  return (
+    <Snap
+      name="RPC Snap"
+      snapId={RPC_SNAP_ID}
+      port={RPC_SNAP_PORT}
+      testId="RpcSnap"
+    >
+      <Button
+        variant="primary"
+        id="sendRpc"
+        className="mb-3"
+        disabled={isLoading}
+        onClick={handleSubmit}
+      >
+        Send Test to RPC Snap
+      </Button>
+      <Result>
+        <span id="rpcResult">
+          {JSON.stringify(data, null, 2)}
+          {JSON.stringify(error, null, 2)}
+        </span>
+      </Result>
+    </Snap>
+  );
+};

--- a/packages/site/src/features/rpc-snap/index.ts
+++ b/packages/site/src/features/rpc-snap/index.ts
@@ -1,0 +1,1 @@
+export * from './Rpc';

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -10,6 +10,7 @@ import { ManageState } from '../features/manage-state-snap';
 import { Notification } from '../features/notification-snap';
 import { BIP32 } from '../features/bip-32-snap';
 import { Update } from '../features/update-snap';
+import { Rpc } from '../features/rpc-snap';
 
 interface Query {
   site: {
@@ -36,6 +37,7 @@ const Index: FunctionComponent = () => {
         <Notification />
         <BIP32 />
         <Update />
+        <Rpc />
       </Row>
     </Container>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2687,12 +2687,8 @@ __metadata:
     "@metamask/eslint-config-jest": ^6.0.0
     "@metamask/eslint-config-nodejs": ^6.0.0
     "@metamask/eslint-config-typescript": ^6.0.0
-    "@metamask/key-tree": ^6.0.0
     "@metamask/snaps-cli": ^0.24.1
     "@metamask/snaps-types": ^0.24.1
-    "@metamask/utils": ^3.3.0
-    "@noble/ed25519": ^1.7.1
-    "@noble/secp256k1": ^1.7.0
     "@types/jest": ^26.0.13
     "@typescript-eslint/eslint-plugin": ^5.19.0
     "@typescript-eslint/parser": ^5.19.0
@@ -2702,7 +2698,6 @@ __metadata:
     eslint-plugin-jest: ^24.4.0
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^3.4.0
-    eth-rpc-errors: ^4.0.3
     jest: ^26.4.2
     prettier: ^2.2.1
     rimraf: ^3.0.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -2678,6 +2678,40 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@metamask/test-snap-rpc@workspace:packages/rpc":
+  version: 0.0.0-use.local
+  resolution: "@metamask/test-snap-rpc@workspace:packages/rpc"
+  dependencies:
+    "@metamask/auto-changelog": ^2.5.0
+    "@metamask/eslint-config": ^6.0.0
+    "@metamask/eslint-config-jest": ^6.0.0
+    "@metamask/eslint-config-nodejs": ^6.0.0
+    "@metamask/eslint-config-typescript": ^6.0.0
+    "@metamask/key-tree": ^6.0.0
+    "@metamask/snaps-cli": ^0.24.1
+    "@metamask/snaps-types": ^0.24.1
+    "@metamask/utils": ^3.3.0
+    "@noble/ed25519": ^1.7.1
+    "@noble/secp256k1": ^1.7.0
+    "@types/jest": ^26.0.13
+    "@typescript-eslint/eslint-plugin": ^5.19.0
+    "@typescript-eslint/parser": ^5.19.0
+    eslint: ^7.30.0
+    eslint-config-prettier: ^8.3.0
+    eslint-plugin-import: ^2.23.4
+    eslint-plugin-jest: ^24.4.0
+    eslint-plugin-node: ^11.1.0
+    eslint-plugin-prettier: ^3.4.0
+    eth-rpc-errors: ^4.0.3
+    jest: ^26.4.2
+    prettier: ^2.2.1
+    rimraf: ^3.0.2
+    ts-jest: ^26.3.0
+    ts-node: ^9.0.0
+    typescript: ^4.4.0
+  languageName: unknown
+  linkType: soft
+
 "@metamask/types@npm:^1.1.0":
   version: 1.1.0
   resolution: "@metamask/types@npm:1.1.0"


### PR DESCRIPTION
This adds a new test snap to test the JSON-RPC endowment permission. The new test snap will result in an error, since it's trying to talk to other Snaps (which don't have permission for it).

It also adds the endowment to all other test Snaps.