### PR TITLE
Add `endowment:rpc` to all snaps

### DIFF
--- a/packages/bip32/snap.manifest.json
+++ b/packages/bip32/snap.manifest.json
@@ -17,6 +17,7 @@
     }
   },
   "initialPermissions": {
+    "endowment:rpc": {},
     "snap_confirm": {},
     "snap_getBip32Entropy": [
       {

--- a/packages/bip32/snap.manifest.json
+++ b/packages/bip32/snap.manifest.json
@@ -17,7 +17,9 @@
     }
   },
   "initialPermissions": {
-    "endowment:rpc": {},
+    "endowment:rpc": {
+      "dapps": true
+    },
     "snap_confirm": {},
     "snap_getBip32Entropy": [
       {

--- a/packages/bip44/snap.manifest.json
+++ b/packages/bip44/snap.manifest.json
@@ -17,7 +17,9 @@
     }
   },
   "initialPermissions": {
-    "endowment:rpc": {},
+    "endowment:rpc": {
+      "dapps": true
+    },
     "snap_confirm": {},
     "snap_getBip44Entropy": [
       {

--- a/packages/bip44/snap.manifest.json
+++ b/packages/bip44/snap.manifest.json
@@ -17,6 +17,7 @@
     }
   },
   "initialPermissions": {
+    "endowment:rpc": {},
     "snap_confirm": {},
     "snap_getBip44Entropy": [
       {

--- a/packages/confirm/snap.manifest.json
+++ b/packages/confirm/snap.manifest.json
@@ -18,7 +18,9 @@
     }
   },
   "initialPermissions": {
-    "endowment:rpc": {},
+    "endowment:rpc": {
+      "dapps": true
+    },
     "snap_confirm": {}
   },
   "manifestVersion": "0.1"

--- a/packages/confirm/snap.manifest.json
+++ b/packages/confirm/snap.manifest.json
@@ -18,6 +18,7 @@
     }
   },
   "initialPermissions": {
+    "endowment:rpc": {},
     "snap_confirm": {}
   },
   "manifestVersion": "0.1"

--- a/packages/error/snap.manifest.json
+++ b/packages/error/snap.manifest.json
@@ -18,7 +18,9 @@
     }
   },
   "initialPermissions": {
-    "endowment:rpc": {},
+    "endowment:rpc": {
+      "dapps": true
+    },
     "snap_confirm": {}
   },
   "manifestVersion": "0.1"

--- a/packages/error/snap.manifest.json
+++ b/packages/error/snap.manifest.json
@@ -18,6 +18,7 @@
     }
   },
   "initialPermissions": {
+    "endowment:rpc": {},
     "snap_confirm": {}
   },
   "manifestVersion": "0.1"

--- a/packages/manageState/snap.manifest.json
+++ b/packages/manageState/snap.manifest.json
@@ -18,6 +18,7 @@
     }
   },
   "initialPermissions": {
+    "endowment:rpc": {},
     "snap_manageState": {}
   },
   "manifestVersion": "0.1"

--- a/packages/manageState/snap.manifest.json
+++ b/packages/manageState/snap.manifest.json
@@ -18,7 +18,9 @@
     }
   },
   "initialPermissions": {
-    "endowment:rpc": {},
+    "endowment:rpc": {
+      "dapps": true
+    },
     "snap_manageState": {}
   },
   "manifestVersion": "0.1"

--- a/packages/notification/snap.manifest.json
+++ b/packages/notification/snap.manifest.json
@@ -18,7 +18,9 @@
     }
   },
   "initialPermissions": {
-    "endowment:rpc": {},
+    "endowment:rpc": {
+      "dapps": true
+    },
     "snap_notify": {}
   },
   "manifestVersion": "0.1"

--- a/packages/notification/snap.manifest.json
+++ b/packages/notification/snap.manifest.json
@@ -18,6 +18,7 @@
     }
   },
   "initialPermissions": {
+    "endowment:rpc": {},
     "snap_notify": {}
   },
   "manifestVersion": "0.1"


### PR DESCRIPTION
Adds `endowment:rpc` to all test snaps, such that the site can communicate with them.