### PR TITLE
Add tx-insights test panel

### DIFF
--- a/packages/insights/.eslintrc.js
+++ b/packages/insights/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['../../.eslintrc.js'],
+
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+};

--- a/packages/insights/CHANGELOG.md
+++ b/packages/insights/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/MetaMask/test-snaps/

--- a/packages/insights/README.md
+++ b/packages/insights/README.md
@@ -1,0 +1,14 @@
+# Transaction Insights Example Snap
+
+This Snap demonstrates how to use the transaction insights feature.
+
+## Notes
+
+- Babel is used for transpiling TypeScript to JavaScript, so when building with the CLI,
+  `transpilationMode` must be set to `localOnly` (default) or `localAndDeps`.
+- For the global `wallet` type to work, you have to add the following to your `tsconfig.json`:
+  ```json
+  {
+    "files": ["./node_modules/@metamask/snaps-types/global.d.ts"]
+  }
+  ```

--- a/packages/insights/package.json
+++ b/packages/insights/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@metamask/test-snap-insights",
+  "version": "4.2.0",
+  "description": "MetaMask Insights Test Snap",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/test-snaps.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "files": [
+    "dist/",
+    "snap.manifest.json",
+    "images/icon.svg"
+  ],
+  "scripts": {
+    "build": "mm-snap build --eval false",
+    "build:dev": "yarn build",
+    "build:clean": "yarn clean && yarn build",
+    "clean": "rimraf 'dist/*'",
+    "start": "mm-snap watch",
+    "test": "jest --passWithNoTests",
+    "test:watch": "jest --watch",
+    "lint:eslint": "eslint . --cache --ext js,ts",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --single-quote --ignore-path ../../.prettierignore --no-error-on-unmatched-pattern",
+    "lint": "yarn lint:eslint && yarn lint:misc --check",
+    "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
+    "lint:changelog": "yarn auto-changelog validate"
+  },
+  "dependencies": {
+    "@metamask/snaps-types": "^0.24.1"
+  },
+  "devDependencies": {
+    "@lavamoat/allow-scripts": "^2.0.3",
+    "@metamask/abi-utils": "1.1.0",
+    "@metamask/auto-changelog": "^2.5.0",
+    "@metamask/eslint-config": "^6.0.0",
+    "@metamask/eslint-config-jest": "^6.0.0",
+    "@metamask/eslint-config-nodejs": "^6.0.0",
+    "@metamask/eslint-config-typescript": "^6.0.0",
+    "@metamask/snaps-cli": "^0.24.1",
+    "@metamask/snaps-types": "^0.24.1",
+    "@metamask/utils": "^3.3.1",
+    "@types/jest": "^26.0.13",
+    "@typescript-eslint/eslint-plugin": "^5.19.0",
+    "@typescript-eslint/parser": "^5.19.0",
+    "eslint": "^7.30.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-import": "^2.23.4",
+    "eslint-plugin-jest": "^24.4.0",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^3.4.0",
+    "jest": "^26.4.2",
+    "prettier": "^2.2.1",
+    "rimraf": "^3.0.2",
+    "ts-jest": "^26.3.0",
+    "ts-node": "^9.0.0",
+    "typescript": "^4.4.0"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  }
+}

--- a/packages/insights/snap.config.js
+++ b/packages/insights/snap.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  cliOptions: {
+    src: './src/index.ts',
+    port: 8008,
+  },
+};

--- a/packages/insights/snap.manifest.json
+++ b/packages/insights/snap.manifest.json
@@ -1,0 +1,24 @@
+{
+  "version": "4.2.0",
+  "description": "An example transaction insights Snap.",
+  "proposedName": "TxInsightsTest",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/test-snaps.git"
+  },
+  "source": {
+    "shasum": "7Eiw/+xd0r4vIk1PAuEmfRNqtFmN4bTC41vgZJlsPdA=",
+    "location": {
+      "npm": {
+        "filePath": "dist/bundle.js",
+        "packageName": "@metamask/test-snap-insights",
+        "registry": "https://registry.npmjs.org/"
+      }
+    }
+  },
+  "initialPermissions": {
+    "endowment:transaction-insight": {},
+    "endowment:network-access": {}
+  },
+  "manifestVersion": "0.1"
+}

--- a/packages/insights/src/index.ts
+++ b/packages/insights/src/index.ts
@@ -1,6 +1,5 @@
 import { OnTransactionHandler } from '@metamask/snaps-types';
 import { hasProperty, isObject, Json } from '@metamask/utils';
-// import { getInsights } from './insights';
 
 /**
  * Handle an incoming transaction, and return any insights.

--- a/packages/insights/src/index.ts
+++ b/packages/insights/src/index.ts
@@ -1,0 +1,23 @@
+import { OnTransactionHandler } from '@metamask/snaps-types';
+import { hasProperty, isObject, Json } from '@metamask/utils';
+// import { getInsights } from './insights';
+
+/**
+ * Handle an incoming transaction, and return any insights.
+ *
+ * @param args - The request handler args as object.
+ * @param args.transaction - The transaction object.
+ * @returns The transaction insights.
+ */
+export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
+  const insights: { type: string, params?: Json } = { type: 'Unknown Transaction' }; 
+  if (
+    !isObject(transaction) ||
+    !hasProperty(transaction, 'data') ||
+    typeof transaction.data !== 'string'
+  ) {
+    console.warn('Unknown transaction type.');
+    return { insights };
+  }
+  return { insights: { Test: 'Successful' } };
+};

--- a/packages/insights/src/index.ts
+++ b/packages/insights/src/index.ts
@@ -13,6 +13,7 @@ export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
   const insights: { type: string; params?: Json } = {
     type: 'Unknown Transaction',
   };
+
   if (
     !isObject(transaction) ||
     !hasProperty(transaction, 'data') ||
@@ -21,5 +22,6 @@ export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
     console.warn('Unknown transaction type.');
     return { insights };
   }
+
   return { insights: { Test: 'Successful' } };
 };

--- a/packages/insights/src/index.ts
+++ b/packages/insights/src/index.ts
@@ -10,7 +10,9 @@ import { hasProperty, isObject, Json } from '@metamask/utils';
  * @returns The transaction insights.
  */
 export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
-  const insights: { type: string, params?: Json } = { type: 'Unknown Transaction' }; 
+  const insights: { type: string; params?: Json } = {
+    type: 'Unknown Transaction',
+  };
   if (
     !isObject(transaction) ||
     !hasProperty(transaction, 'data') ||

--- a/packages/insights/tsconfig.json
+++ b/packages/insights/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.packages.json",
+  "compilerOptions": {
+    "typeRoots": ["../../../../node_modules/@types"]
+  },
+  "files": ["../../../snaps-types/global.d.ts"],
+  "include": ["src"]
+}

--- a/packages/site/src/api.ts
+++ b/packages/site/src/api.ts
@@ -10,6 +10,7 @@ declare global {
 }
 
 export enum Tag {
+  Accounts = 'Accounts',
   InstalledSnaps = 'Installed Snaps',
   TestState = 'Test State',
 }
@@ -63,9 +64,16 @@ export type InstallSnapResult = Record<string, { error: JsonRpcError }>;
 export const baseApi = createApi({
   reducerPath: 'base',
   baseQuery: request,
-  tagTypes: [Tag.InstalledSnaps, Tag.TestState],
+  tagTypes: [Tag.Accounts, Tag.InstalledSnaps, Tag.TestState],
   endpoints(build) {
     return {
+      getAccounts: build.query<string[], void>({
+        query: () => ({
+          method: 'eth_requestAccounts',
+        }),
+        providesTags: [Tag.Accounts],
+      }),
+
       getSnaps: build.query<GetSnapsResult, void>({
         query: () => ({
           method: 'wallet_getSnaps',
@@ -79,6 +87,10 @@ export const baseApi = createApi({
           params: { snapId, request: params ? { method, params } : { method } },
         }),
         providesTags: (_, __, { tags = [] }) => tags,
+      }),
+
+      request: build.query<RequestArguments, unknown>({
+        query: (args: RequestArguments) => args,
       }),
 
       invokeMutation: build.mutation<InvokeSnapResult, InvokeSnapArgs>({
@@ -113,8 +125,11 @@ export const baseApi = createApi({
 });
 
 export const {
+  useGetAccountsQuery,
+  useLazyGetAccountsQuery,
   useGetSnapsQuery,
   useInvokeQueryQuery: useInvokeQuery,
+  useLazyRequestQuery,
   useInvokeMutationMutation: useInvokeMutation,
   useInstallSnapMutation,
 } = baseApi;

--- a/packages/site/src/features/insights-snap/Insights.tsx
+++ b/packages/site/src/features/insights-snap/Insights.tsx
@@ -1,24 +1,16 @@
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useState } from 'react';
 import { Button } from 'react-bootstrap';
-import { Result, Snap } from '../../components';
-import { useInvokeMutation } from '../../api';
-import { getSnapId } from '../../utils';
+import { Snap } from '../../components';
 
 const INSIGHTS_SNAP_ID = 'npm:@metamask/test-snap-insights';
 const INSIGHTS_SNAP_PORT = 8008;
 
 export const Insights: FunctionComponent = () => {
-  const [invokeSnap, { isLoading, data, error }] = useInvokeMutation();
-
-  const handleSubmit = () => {
-    invokeSnap({
-      snapId: getSnapId(INSIGHTS_SNAP_ID, INSIGHTS_SNAP_PORT),
-      method: 'getInsights',
-    });
-  };
+  const [isLoading, setIsLoading] = useState(false);
 
   const sendIt = async () => {
     try {
+      setIsLoading(true);
       const [from] = (await window.ethereum.request({
         method: 'eth_requestAccounts',
       })) as string[];
@@ -40,6 +32,8 @@ export const Insights: FunctionComponent = () => {
       });
     } catch (e) {
       console.error(e);
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -52,16 +46,6 @@ export const Insights: FunctionComponent = () => {
     >
       <Button
         variant="primary"
-        id="sendInsightsError"
-        className="mb-3"
-        hidden={true}
-        disabled={true}
-        onClick={handleSubmit}
-      >
-        This button is intentionally hidden
-      </Button>
-      <Button
-        variant="primary"
         id="sendInsights"
         className="mb-3"
         disabled={isLoading}
@@ -69,12 +53,6 @@ export const Insights: FunctionComponent = () => {
       >
         Send Transaction
       </Button>
-      <Result>
-        <span id="insightsResult">
-          {JSON.stringify(data, null, 2)}
-          {JSON.stringify(error, null, 2)}
-        </span>
-      </Result>
     </Snap>
   );
 };

--- a/packages/site/src/features/insights-snap/Insights.tsx
+++ b/packages/site/src/features/insights-snap/Insights.tsx
@@ -1,0 +1,80 @@
+import { FunctionComponent } from 'react';
+import { Button } from 'react-bootstrap';
+import { Result, Snap } from '../../components';
+import { useInvokeMutation } from '../../api';
+import { getSnapId } from '../../utils';
+
+const INSIGHTS_SNAP_ID = 'npm:@metamask/test-snap-insights';
+const INSIGHTS_SNAP_PORT = 8008;
+
+export const Insights: FunctionComponent = () => {
+  const [invokeSnap, { isLoading, data, error }] = useInvokeMutation();
+
+  const handleSubmit = () => {
+    invokeSnap({
+      snapId: getSnapId(INSIGHTS_SNAP_ID, INSIGHTS_SNAP_PORT),
+      method: 'getInsights',
+    });
+  };
+
+  const sendIt = async () => {
+    try {
+      const [from] = (await window.ethereum.request({
+        method: 'eth_requestAccounts',
+      })) as string[];
+
+      if (!from) {
+        throw new Error('Failed to get accounts.');
+      }
+
+      await window.ethereum.request({
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            from,
+            to: '0x08A8fDBddc160A7d5b957256b903dCAb1aE512C5',
+            value: '0x0',
+            data: '0x1',
+          },
+        ],
+      });
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <Snap
+      name="Insights Snap"
+      snapId={INSIGHTS_SNAP_ID}
+      port={INSIGHTS_SNAP_PORT}
+      testId="InsightsSnap"
+    >
+      <Button
+        variant="primary"
+        id="sendInsightsError"
+        className="mb-3"
+        hidden={true}
+        disabled={true}
+        onClick={handleSubmit}
+      >
+        This button is intentionally hidden
+      </Button>
+      <Button
+        variant="primary"
+        id="sendInsights"
+        className="mb-3"
+        disabled={isLoading}
+        onClick={sendIt}
+      >
+        Send Transaction
+      </Button>
+      <Result>
+        <span id="insightsResult">
+          {JSON.stringify(data, null, 2)}
+          {JSON.stringify(error, null, 2)}
+        </span>
+      </Result>
+    </Snap>
+  );
+};

--- a/packages/site/src/features/insights-snap/index.ts
+++ b/packages/site/src/features/insights-snap/index.ts
@@ -1,0 +1,1 @@
+export * from './Insights';

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -11,6 +11,7 @@ import { Notification } from '../features/notification-snap';
 import { BIP32 } from '../features/bip-32-snap';
 import { Update } from '../features/update-snap';
 import { Rpc } from '../features/rpc-snap';
+import { Insights } from '../features/insights-snap';
 
 interface Query {
   site: {
@@ -37,6 +38,7 @@ const Index: FunctionComponent = () => {
         <Notification />
         <BIP32 />
         <Update />
+        <Insights />
         <Rpc />
       </Row>
     </Container>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2150,7 +2150,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lavamoat/allow-scripts@npm:^2.1.0":
+"@lavamoat/allow-scripts@npm:^2.0.3, @lavamoat/allow-scripts@npm:^2.1.0":
   version: 2.1.0
   resolution: "@lavamoat/allow-scripts@npm:2.1.0"
   dependencies:
@@ -2260,6 +2260,16 @@ __metadata:
   version: 2.5.3
   resolution: "@lmdb/lmdb-win32-x64@npm:2.5.3"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@metamask/abi-utils@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@metamask/abi-utils@npm:1.1.0"
+  dependencies:
+    "@metamask/utils": ^3.2.0
+    superstruct: ^0.16.5
+  checksum: 9b199a856b4fc5ee034cc64f776977f2d38eae78c5f08c6a485d2479c9230ec40bd0e3e299e924acdf0dffa6cafe50921e4b43a2319cbc0a25bdc95aed316645
   languageName: node
   linkType: hard
 
@@ -2602,6 +2612,38 @@ __metadata:
     "@metamask/eslint-config-typescript": ^6.0.0
     "@metamask/snaps-cli": ^0.24.1
     "@metamask/snaps-types": ^0.24.1
+    "@types/jest": ^26.0.13
+    "@typescript-eslint/eslint-plugin": ^5.19.0
+    "@typescript-eslint/parser": ^5.19.0
+    eslint: ^7.30.0
+    eslint-config-prettier: ^8.3.0
+    eslint-plugin-import: ^2.23.4
+    eslint-plugin-jest: ^24.4.0
+    eslint-plugin-node: ^11.1.0
+    eslint-plugin-prettier: ^3.4.0
+    jest: ^26.4.2
+    prettier: ^2.2.1
+    rimraf: ^3.0.2
+    ts-jest: ^26.3.0
+    ts-node: ^9.0.0
+    typescript: ^4.4.0
+  languageName: unknown
+  linkType: soft
+
+"@metamask/test-snap-insights@workspace:packages/insights":
+  version: 0.0.0-use.local
+  resolution: "@metamask/test-snap-insights@workspace:packages/insights"
+  dependencies:
+    "@lavamoat/allow-scripts": ^2.0.3
+    "@metamask/abi-utils": 1.1.0
+    "@metamask/auto-changelog": ^2.5.0
+    "@metamask/eslint-config": ^6.0.0
+    "@metamask/eslint-config-jest": ^6.0.0
+    "@metamask/eslint-config-nodejs": ^6.0.0
+    "@metamask/eslint-config-typescript": ^6.0.0
+    "@metamask/snaps-cli": ^0.24.1
+    "@metamask/snaps-types": ^0.24.1
+    "@metamask/utils": ^3.3.1
     "@types/jest": ^26.0.13
     "@typescript-eslint/eslint-plugin": ^5.19.0
     "@typescript-eslint/parser": ^5.19.0
@@ -17133,7 +17175,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"superstruct@npm:^0.16.7":
+"superstruct@npm:^0.16.5, superstruct@npm:^0.16.7":
   version: 0.16.7
   resolution: "superstruct@npm:0.16.7"
   checksum: c8c855ff6945da8a41048c6d236de7b1af5d4d9c31742b3ee54d65647c31597488620281f65e095d5efc9e2fbdaad529b8c8f2506c12569d428467c835a21477


### PR DESCRIPTION
This adds a panel in the test-snaps page to test tx-insights.

This references issue #85 

Improvements need to be made:

- There is a hidden button because the react version was coded to use invokeSnap for every panel, removing it causes problems so this is a temporary solution. 
- The data inside the txinsights tab needs an id or to be read and evaluated. [extension]
-  As of right now the test only checks that the txinsights tab is clickable. [extension]