### PR TITLE
Deploy site to latest, staging, and rc

### DIFF
--- a/.github/workflows/publish-main-site.yml
+++ b/.github/workflows/publish-main-site.yml
@@ -1,0 +1,14 @@
+name: Publish main branch site to GitHub Pages
+
+on:
+  push:
+    branches: main
+
+jobs:
+  publish-to-gh-pages:
+    name: Publish site to `staging` directory of `gh-pages` branch
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-site.yml
+    with:
+      destination_dir: staging

--- a/.github/workflows/publish-rc-site.yml
+++ b/.github/workflows/publish-rc-site.yml
@@ -1,0 +1,26 @@
+name: Publish release candidate site to GitHub Pages
+
+on:
+  push:
+    branches: 'release/**'
+
+jobs:
+  get-release-version:
+    name: Get release version
+    runs-on: ubuntu-latest
+    outputs:
+      release-version: ${{ steps.release-name.outputs.RELEASE_VERSION }}
+    steps:
+      - name: Extract release version from branch name
+        id: release-name
+        run: |
+          BRANCH_NAME='${{ github.ref_name }}'
+          echo "RELEASE_VERSION=v${BRANCH_NAME#release/}" >> "$GITHUB_OUTPUT"
+  publish-to-gh-pages:
+    name: Publish site to `rc-${{ needs.get-release-version.outputs.release-version }}` directory of `gh-pages` branch
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-site.yml
+    needs: get-release-version
+    with:
+      destination_dir: rc-${{ needs.get-release-version.outputs.release-version }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           path: |
             ./packages/*/dist
-            ./packages/site/public
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
 
@@ -47,7 +46,6 @@ jobs:
         with:
           path: |
             ./packages/*/dist
-            ./packages/site/public
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
       - name: Dry Run Publish
@@ -69,7 +67,6 @@ jobs:
         with:
           path: |
             ./packages/*/dist
-            ./packages/site/public
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
       - name: Publish
@@ -95,26 +92,19 @@ jobs:
         run: ./scripts/get.sh ".version" "RELEASE_VERSION"
 
   publish-release-to-gh-pages:
-    runs-on: ubuntu-latest
     needs: get-release-version
-    name: Publish release to `${{ needs.get-release-version.outputs.RELEASE_VERSION }}` directory of `gh-pages` branch
+    name: Publish site to `${{ needs.get-release-version.outputs.RELEASE_VERSION }}` directory of `gh-pages` branch
     permissions:
       contents: write
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.sha }}
-      - uses: actions/cache@v3
-        id: restore-build
-        with:
-          path: |
-            ./packages/*/dist
-            ./packages/site/public
-            ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
-      - name: Deploy to `${{ needs.get-release-version.outputs.RELEASE_VERSION }}` directory of `gh-pages` branch
-        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./packages/site/public
-          destination_dir: ${{ needs.get-release-version.outputs.RELEASE_VERSION }}
+    uses: ./.github/workflows/publish-site.yml
+    with:
+      destination_dir: ${{ needs.get-release-version.outputs.RELEASE_VERSION }}
+
+  publish-release-to-latest-gh-pages:
+    needs: publish-npm
+    name: Publish site to `latest` directory of `gh-pages` branch
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-site.yml
+    with:
+      destination_dir: latest

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -1,0 +1,36 @@
+name: Publish site to GitHub Pages
+
+on:
+  workflow_call:
+    inputs:
+      destination_dir:
+        required: true
+        type: string
+
+jobs:
+  publish-site-to-gh-pages:
+    name: Publish site to GitHub Pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Ensure `destination_dir` is not empty
+        if: ${{ inputs.destination_dir == '' }}
+        run: exit 1
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+      - name: Install npm dependencies
+        run: yarn --immutable
+      - name: Run build script
+        run: yarn workspace website build
+      - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
+        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./packages/site/public
+          destination_dir: ${{ inputs.destination_dir }}

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -28,6 +28,8 @@ jobs:
         run: yarn --immutable
       - name: Run build script
         run: yarn workspace website build
+        env:
+          GATSBY_PREFIX: ${{ inputs.destination_dir }}
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
         uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305
         with:

--- a/packages/site/gatsby-config.ts
+++ b/packages/site/gatsby-config.ts
@@ -6,7 +6,10 @@ const config: GatsbyConfig = {
   // in every file.
   jsxRuntime: 'automatic',
 
-  pathPrefix: `/test-snaps/${packageJson.version}`,
+  // If a `GATSBY_PREFIX` environment variable is set, we use it as the path
+  // prefix. This is set in CI to ensure that the site is built with the correct
+  // path prefix. Otherwise, we use the `package.json` version.
+  pathPrefix: `/test-snaps/${process.env.GATSBY_PREFIX ?? packageJson.version}`,
 
   siteMetadata: {
     title: 'Test Snaps',


### PR DESCRIPTION
This changes how the site is deployed:

- It's deployed to the `staging` folder on pushes to the main branch.
- It's deployed to the `rc-${version}` folder when a release is created.
- It's deployed to the `${version}` and `latest` folder when a release is published.

Closes #109.