### PR TITLE
Add more RTK query helpers and simplify transaction insights test

### DIFF
--- a/packages/insights/CHANGELOG.md
+++ b/packages/insights/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/MetaMask/test-snaps/

--- a/packages/insights/src/index.ts
+++ b/packages/insights/src/index.ts
@@ -13,6 +13,7 @@ export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
   const insights: { type: string; params?: Json } = {
     type: 'Unknown Transaction',
   };
+
   if (
     !isObject(transaction) ||
     !hasProperty(transaction, 'data') ||
@@ -21,5 +22,6 @@ export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
     console.warn('Unknown transaction type.');
     return { insights };
   }
+
   return { insights: { Test: 'Successful' } };
 };

--- a/packages/site/src/api.ts
+++ b/packages/site/src/api.ts
@@ -10,6 +10,7 @@ declare global {
 }
 
 export enum Tag {
+  Accounts = 'Accounts',
   InstalledSnaps = 'Installed Snaps',
   TestState = 'Test State',
 }
@@ -63,9 +64,16 @@ export type InstallSnapResult = Record<string, { error: JsonRpcError }>;
 export const baseApi = createApi({
   reducerPath: 'base',
   baseQuery: request,
-  tagTypes: [Tag.InstalledSnaps, Tag.TestState],
+  tagTypes: [Tag.Accounts, Tag.InstalledSnaps, Tag.TestState],
   endpoints(build) {
     return {
+      getAccounts: build.query<string[], void>({
+        query: () => ({
+          method: 'eth_requestAccounts',
+        }),
+        providesTags: [Tag.Accounts],
+      }),
+
       getSnaps: build.query<GetSnapsResult, void>({
         query: () => ({
           method: 'wallet_getSnaps',
@@ -79,6 +87,10 @@ export const baseApi = createApi({
           params: { snapId, request: params ? { method, params } : { method } },
         }),
         providesTags: (_, __, { tags = [] }) => tags,
+      }),
+
+      request: build.query<RequestArguments, unknown>({
+        query: (args: RequestArguments) => args,
       }),
 
       invokeMutation: build.mutation<InvokeSnapResult, InvokeSnapArgs>({
@@ -113,8 +125,11 @@ export const baseApi = createApi({
 });
 
 export const {
+  useGetAccountsQuery,
+  useLazyGetAccountsQuery,
   useGetSnapsQuery,
   useInvokeQueryQuery: useInvokeQuery,
+  useLazyRequestQuery,
   useInvokeMutationMutation: useInvokeMutation,
   useInstallSnapMutation,
 } = baseApi;

--- a/packages/site/src/features/insights-snap/Insights.tsx
+++ b/packages/site/src/features/insights-snap/Insights.tsx
@@ -48,7 +48,7 @@ export const Insights: FunctionComponent = () => {
           variant="primary"
           id="getAccounts"
           className="mb-3"
-          disabled={isLoading}
+          disabled={isLoading || accounts?.length}
           onClick={handleGetAccounts}
         >
           Get Accounts

--- a/packages/site/src/features/insights-snap/Insights.tsx
+++ b/packages/site/src/features/insights-snap/Insights.tsx
@@ -48,7 +48,7 @@ export const Insights: FunctionComponent = () => {
           variant="primary"
           id="getAccounts"
           className="mb-3"
-          disabled={isLoading || accounts?.length}
+          disabled={isLoading}
           onClick={handleGetAccounts}
         >
           Get Accounts


### PR DESCRIPTION
This adds a `getAccounts` and generic `request` query helper, which are used in the transaction insights test.