### PR TITLE
Remove network-access endowment from tx-insight test

### DIFF
--- a/packages/insights/snap.manifest.json
+++ b/packages/insights/snap.manifest.json
@@ -17,8 +17,7 @@
     }
   },
   "initialPermissions": {
-    "endowment:transaction-insight": {},
-    "endowment:network-access": {}
+    "endowment:transaction-insight": {}
   },
   "manifestVersion": "0.1"
 }


### PR DESCRIPTION
Removes `endowment:network-access` from the tx insight test snap because it doesn't need that permission.