### PR TITLE
Fixes for RPC endowment test-snap

### DIFF
--- a/packages/bip32/snap.manifest.json
+++ b/packages/bip32/snap.manifest.json
@@ -18,7 +18,8 @@
   },
   "initialPermissions": {
     "endowment:rpc": {
-      "dapps": true
+      "dapps": true,
+      "snaps": true
     },
     "snap_confirm": {},
     "snap_getBip32Entropy": [

--- a/packages/rpc/snap.manifest.json
+++ b/packages/rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "thN1a0kN7oUO7D3qlo6tPZ0o0g9ldVdlHDA6VwALQU4=",
+    "shasum": "cDaKGyry9MtzwUoRpN6YNyFa7PlUUknrgh5/6xJuFyI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/rpc/snap.manifest.json
+++ b/packages/rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "g7T1uCi+lZNdSo85d4ixmkC9DsoBDe99Lv1wLRu/Iz8=",
+    "shasum": "thN1a0kN7oUO7D3qlo6tPZ0o0g9ldVdlHDA6VwALQU4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -1,7 +1,6 @@
 import { OnRpcRequestHandler } from '@metamask/snaps-types';
 
-// const OTHER_SNAP_ID = 'npm:@metamask/test-snap-bip32';
-const OTHER_SNAP_ID = 'local:http://localhost:8006';
+const OTHER_SNAP_ID = 'npm:@metamask/test-snap-bip32';
 
 /**
  * Request access to {@link OTHER_SNAP_ID} if it is not already connected.

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -1,6 +1,7 @@
 import { OnRpcRequestHandler } from '@metamask/snaps-types';
 
-const OTHER_SNAP_ID = 'npm:@metamask/test-snap-bip32';
+// const OTHER_SNAP_ID = 'npm:@metamask/test-snap-bip32';
+const OTHER_SNAP_ID = 'local:http://localhost:8006';
 
 /**
  * Request access to {@link OTHER_SNAP_ID} if it is not already connected.
@@ -32,6 +33,11 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
           snapId: OTHER_SNAP_ID,
           request: {
             method: 'getPublicKey',
+            params: {
+              path: ['m', "44'", "0'"],
+              curve: 'secp256k1',
+              compressed: true,
+            },
           },
         },
       });


### PR DESCRIPTION
Problems with the way the original test snap for the RPC endowment caused the test of inter-snap communication to fail, and this has now been fixed.