### PR TITLE
Update shasums to use new calculation

### DIFF
--- a/packages/bip32/snap.manifest.json
+++ b/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "rr4zYTeeTpTiGAlB/J/9rTkv6CuoQVEm/gMeWafvANQ=",
+    "shasum": "2FFC3cdjmaWB9GhrIpr0IjLovgaia+CuQQTIgimvAYU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/bip44/snap.manifest.json
+++ b/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "YhLTlRGoLz+WfRxinPPju2A7I0daNcwTNU5NOPfHKrA=",
+    "shasum": "BVZi8T6Oh/Gam50dsyIuJOmqAczOqP/fbbRbvD/fDGU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/confirm/snap.manifest.json
+++ b/packages/confirm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "olbB10xXRoPl3p+/0qB6+fGGgXQ6t4uwFDyQ2iqHrF4=",
+    "shasum": "IF+QqRBvRRF5O7g/ExXdYz4524Q+65vJKhUQbBn69ZE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/cronjob/snap.manifest.json
+++ b/packages/cronjob/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "BFD6zxK5fNJ9TO3iICSA/SfPjlpUUxQtO7kwpyx7NDE=",
+    "shasum": "9L4m7fDi8NJLI6A3ZtdXjpcpgytUnUo1F5i9pg2fd48=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/dialog/snap.manifest.json
+++ b/packages/dialog/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "r2Em5K6t9OiGsR+szqrhVtemOGlmkw0CXEM1AFiuCVo=",
+    "shasum": "duh2B5vemRd3W1rFY5HYWByKqlEEGXuAcILhLzeITYw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/error/snap.manifest.json
+++ b/packages/error/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "sKAjoK/AtuUmDJqm38HYEXrMcWeYL+27Y51uGiNZ+XM=",
+    "shasum": "w4SHUvROGgx0io4+wzaEJ507tBmg7ksh+ipBI+BYMJ8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/insights/snap.manifest.json
+++ b/packages/insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "ZGhbqAUGKjJ9x2dIFop2lfl9NHIVR5+k4TlvZgkogdo=",
+    "shasum": "bjFf6ZJF0ZwWkTd3s4DDqqA9tHO8kj1zqq55JgN2K+U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/manageState/snap.manifest.json
+++ b/packages/manageState/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "dfZrrxkm9NbYSaoc7VpZ5UM8SpDpcCj68jhdLVQTAIY=",
+    "shasum": "rDY4ct+bY0xm3C0rOASqE2yDHYsKCzDImgAtZR4Okbo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/notification/snap.manifest.json
+++ b/packages/notification/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "FmNRiSbpDqmuiGj7Z7LGSNv5rk2pK/PEhFbllvd5mSM=",
+    "shasum": "Xn608h+EnLnJiqBSYxzGbw48mdD3r/6u+aQfpwvpd/4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/rpc/snap.manifest.json
+++ b/packages/rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "cDaKGyry9MtzwUoRpN6YNyFa7PlUUknrgh5/6xJuFyI=",
+    "shasum": "iefAgoSiNiS1VRWoZ493Y1p60hG/wzQ4ZHAV+TXVmGU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
Checksum calculation has changed in MetaMask/snaps-monorepo#1128. This PR updates the checksums to use the new method of calculation.

Pending a release of `snaps-cli`.