### PR TITLE
Fix dialog snap & site code

### DIFF
--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -32,6 +32,7 @@
     "lint:changelog": "yarn auto-changelog validate"
   },
   "dependencies": {
+    "@metamask/rpc-methods": "0.29.0",
     "@metamask/snaps-types": "^0.26.2",
     "@metamask/snaps-ui": "^0.27.1"
   },

--- a/packages/dialog/snap.manifest.json
+++ b/packages/dialog/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "h9hkqKjh62WCaLs4xkbC92d5/5jCDNmeV8tzLjNGt7M=",
+    "shasum": "xBMUZ2LqlOSiOJfvgOpewZ6Nyw5Gf2Z/zMAig2a010o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -1,3 +1,4 @@
+import { DialogType } from '@metamask/rpc-methods';
 import { OnRpcRequestHandler } from '@metamask/snaps-types';
 import { panel, text, heading } from '@metamask/snaps-ui';
 
@@ -7,7 +8,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       return snap.request({
         method: 'snap_dialog',
         params: {
-          type: 'Alert',
+          type: DialogType.Alert,
           content: panel([heading('Alert Dialog'), text('Text here')]),
         },
       });
@@ -15,7 +16,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       return snap.request({
         method: 'snap_dialog',
         params: {
-          type: 'Confirmation',
+          type: DialogType.Confirmation,
           content: panel([heading('Confirmation Dialog'), text('Text here')]),
         },
       });
@@ -23,7 +24,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       return snap.request({
         method: 'snap_dialog',
         params: {
-          type: 'Prompt',
+          type: DialogType.Prompt,
           content: panel([heading('Prompt Dialog'), text('Text here')]),
           placeholder: 'placeholder',
         },

--- a/packages/site/src/features/update-snap/Update.tsx
+++ b/packages/site/src/features/update-snap/Update.tsx
@@ -8,8 +8,8 @@ import {
 } from '../../api';
 
 const UPDATE_SNAP_ID = 'npm:@metamask/test-snap-bip32';
-const UPDATE_SNAP_OLD_VERSION = '4.0.1';
-const UPDATE_SNAP_NEW_VERSION = '4.0.2';
+const UPDATE_SNAP_OLD_VERSION = '4.6.3';
+const UPDATE_SNAP_NEW_VERSION = '4.6.4';
 
 export const Update: FunctionComponent = () => {
   const [installSnap, { isLoading }] = useInstallSnapMutation();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2310,6 +2310,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/browser-passworder@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@metamask/browser-passworder@npm:4.0.2"
+  checksum: 997c330b1c72f7135d0fd2a7f4b0dce37b3c2e6b30e92f048fa8d4f8c949f5b669dcc3064790f41df30ee2e53a9e64a812df72e00527736be704cce2cf4f6e49
+  languageName: node
+  linkType: hard
+
 "@metamask/controller-utils@npm:^2.0.0":
   version: 2.0.0
   resolution: "@metamask/controller-utils@npm:2.0.0"
@@ -2432,6 +2439,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/key-tree@npm:^6.2.1":
+  version: 6.2.1
+  resolution: "@metamask/key-tree@npm:6.2.1"
+  dependencies:
+    "@metamask/scure-bip39": ^2.1.0
+    "@metamask/utils": ^3.3.0
+    "@noble/ed25519": ^1.6.0
+    "@noble/hashes": ^1.0.0
+    "@noble/secp256k1": ^1.5.5
+    "@scure/base": ^1.0.0
+  checksum: 78931e20a2c933535c17d21e092dbc66e3e96f3c171a6814af51830b7774dd3b4059326180a3b1f52e48a258254a7ea70a31d0c335bf24a8c4250f8d196bc7ba
+  languageName: node
+  linkType: hard
+
 "@metamask/object-multiplex@npm:^1.1.0":
   version: 1.2.0
   resolution: "@metamask/object-multiplex@npm:1.2.0"
@@ -2503,10 +2524,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/rpc-methods@npm:0.29.0":
+  version: 0.29.0
+  resolution: "@metamask/rpc-methods@npm:0.29.0"
+  dependencies:
+    "@metamask/browser-passworder": ^4.0.2
+    "@metamask/key-tree": ^6.2.1
+    "@metamask/permission-controller": ^2.0.0
+    "@metamask/snaps-ui": ^0.29.0
+    "@metamask/snaps-utils": ^0.29.0
+    "@metamask/types": ^1.1.0
+    "@metamask/utils": ^3.4.1
+    "@noble/hashes": ^1.1.3
+    eth-rpc-errors: ^4.0.2
+    nanoid: ^3.1.31
+    superstruct: ^1.0.3
+  checksum: eb317beddd32da9c078bc86c2dcd9183ae8b18f413d76c13e0c236b6ffb8e41ca91f81501f2353f2ad0ce7ba14d6a6ab2d2892730c7bb351d22a20695024d974
+  languageName: node
+  linkType: hard
+
 "@metamask/safe-event-emitter@npm:^2.0.0":
   version: 2.0.0
   resolution: "@metamask/safe-event-emitter@npm:2.0.0"
   checksum: 8b717ac5d53df0027c05509f03d0534700b5898dd1c3a53fb2dc4c0499ca5971b14aae67f522d09eb9f509e77f50afa95fdb3eda1afbff8b071c18a3d2905e93
+  languageName: node
+  linkType: hard
+
+"@metamask/scure-bip39@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@metamask/scure-bip39@npm:2.1.0"
+  dependencies:
+    "@noble/hashes": ~1.1.1
+    "@scure/base": ~1.1.0
+  checksum: 13e07f03077472e9b230f702cbba7848ecac752028396647ccdeedd7bc280ceb50ee15203e25603f05c4c6ca5d4dc7277825f7004beb113e1a415adc91f059f9
   languageName: node
   linkType: hard
 
@@ -2784,6 +2834,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^6.0.0
     "@metamask/eslint-config-nodejs": ^6.0.0
     "@metamask/eslint-config-typescript": ^6.0.0
+    "@metamask/rpc-methods": 0.29.0
     "@metamask/snaps-cli": ^0.29.0
     "@metamask/snaps-types": ^0.26.2
     "@metamask/snaps-ui": ^0.27.1


### PR DESCRIPTION
Tests in the extension are breaking because of a mismatch of dialog types (so I use the enum) and the site fetches older versions of the bip32 snap which no longer satsify the shasum algorithm. Updated the versions to include the latest version and the forthcoming version.