### PR TITLE
Use `package.json` version for installing snap

### DIFF
--- a/packages/rpc/snap.manifest.json
+++ b/packages/rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "43wp7lA/2zTC7CpFxri2i9bXfcOOClaGw24QlhiUWqY=",
+    "shasum": "O3QhjfY4EeX+JJF+kPPOi+oh8PbH0Tjioz9mbyiTAl8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -1,4 +1,5 @@
 import { OnRpcRequestHandler } from '@metamask/snaps-types';
+import packageJson from '../package.json';
 
 const OTHER_SNAP_ID = 'npm:@metamask/test-snap-bip32';
 
@@ -15,7 +16,9 @@ const requestSnap = async () => {
     await snap.request({
       method: 'wallet_requestSnaps',
       params: {
-        [OTHER_SNAP_ID]: {},
+        [OTHER_SNAP_ID]: {
+          version: packageJson.version,
+        },
       },
     });
   }

--- a/packages/rpc/tsconfig.json
+++ b/packages/rpc/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": ["DOM", "ES2020"],
     "outDir": "build",
-    "rootDir": "src"
+    "rootDir": "."
   },
   "exclude": ["./src/**/*.test.ts", "./build"],
   "include": ["./src/**/*.ts"]


### PR DESCRIPTION
The JSON-RPC test snap was previously using the latest version of the BIP-32 test snap for testing. This can cause problems in certain situations (i.e., when checksum calculation has changed). To avoid this, the same version as the current JSON-RPC test snap version should be used instead.