### PR TITLE
Stop transpiling BIP-44 snap dependencies

### DIFF
--- a/packages/bip44/snap.config.js
+++ b/packages/bip44/snap.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   cliOptions: {
     port: 8003,
-    src: './src/index.ts',
-    transpilationMode: 'localAndDeps',
+    src: './src/index.ts'
   },
 };

--- a/packages/bip44/snap.config.js
+++ b/packages/bip44/snap.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   cliOptions: {
     port: 8003,
-    src: './src/index.ts'
+    src: './src/index.ts',
   },
 };

--- a/packages/bip44/snap.manifest.json
+++ b/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "53PexHwogLBtYo/+TKvrdkUjIFKwfk4LTkb4akz1yUY=",
+    "shasum": "SnMVDQ/yhvULH8GAWkioNn1gfcUnjjsg6MCnlPZHZOA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
Stop transpiling BIP-44 snap dependencies since this breaks under SES for these specific dependencies.