### PR TITLE
Bump `peaceiris/actions-gh-pages` to more recent version

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           GATSBY_PREFIX: ${{ inputs.destination_dir }}
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
-        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305
+        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./packages/site/public


### PR DESCRIPTION
This bumps `peaceiris/actions-gh-pages` to a more recent version, to remove the use of Node.js 12.