### PR TITLE
Stop using `wallet_requestSnaps` inside snaps

### DIFF
--- a/packages/rpc/snap.manifest.json
+++ b/packages/rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "JU3Nux9oEhbzgrk4Ubh8P1FIEq7We2IzqzpZ4H7GpE0=",
+    "shasum": "ms5F7HdvlGnPTfqjR2KQcQWS+/65IZjqqvGx01KLHt8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -19,6 +19,18 @@
   "initialPermissions": {
     "endowment:rpc": {
       "dapps": true
+    },
+    "wallet_snap": {
+      "caveats": [
+        {
+          "type": "snapIds",
+          "value": {
+            "npm:@metamask/test-snap-bip32": {
+              "version": "5.0.3"
+            }
+          }
+        }
+      ]
     }
   },
   "manifestVersion": "0.1"

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -3,7 +3,6 @@ import { OnRpcRequestHandler } from '@metamask/snaps-types';
 export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   switch (request.method) {
     case 'send': {
-
       return snap.request({
         method: 'wallet_invokeSnap',
         params: {

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -1,38 +1,13 @@
 import { OnRpcRequestHandler } from '@metamask/snaps-types';
-import packageJson from '../package.json';
-
-const OTHER_SNAP_ID = 'npm:@metamask/test-snap-bip32';
-
-/**
- * Request access to {@link OTHER_SNAP_ID} if it is not already connected.
- */
-const requestSnap = async () => {
-  const snaps = (await snap.request({ method: 'wallet_getSnaps' })) as Record<
-    string,
-    unknown
-  >;
-
-  if (!snaps[OTHER_SNAP_ID]) {
-    await snap.request({
-      method: 'wallet_requestSnaps',
-      params: {
-        [OTHER_SNAP_ID]: {
-          version: packageJson.version,
-        },
-      },
-    });
-  }
-};
 
 export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   switch (request.method) {
     case 'send': {
-      await requestSnap();
 
       return snap.request({
         method: 'wallet_invokeSnap',
         params: {
-          snapId: OTHER_SNAP_ID,
+          snapId: 'npm:@metamask/test-snap-bip32',
           request: {
             method: 'getPublicKey',
             params: {


### PR DESCRIPTION
Stop using `wallet_requestSnaps` inside test snaps since that is not allowed anymore.