### PR TITLE
Patch luxon to fix LavaMoat issue

### DIFF
--- a/.yarn/patches/luxon-npm-3.1.0-16e2508500.patch
+++ b/.yarn/patches/luxon-npm-3.1.0-16e2508500.patch
@@ -1,0 +1,22 @@
+diff --git a/build/cjs-browser/luxon.js b/build/cjs-browser/luxon.js
+index 9ab2b9fd75714368c9c71975ea280bf5d49cb237..14c2891068731bb8bd4ac834d22fb5525a5ed162 100644
+--- a/build/cjs-browser/luxon.js
++++ b/build/cjs-browser/luxon.js
+@@ -7373,7 +7373,7 @@ var DateTime = /*#__PURE__*/function () {
+    */
+   ;
+ 
+-  _proto.toLocaleString = function toLocaleString(formatOpts, opts) {
++  Reflect.defineProperty(_proto, 'toLocaleString', { value: function toLocaleString(formatOpts, opts) {
+     if (formatOpts === void 0) {
+       formatOpts = DATE_SHORT;
+     }
+@@ -7383,7 +7383,7 @@ var DateTime = /*#__PURE__*/function () {
+     }
+ 
+     return this.isValid ? Formatter.create(this.loc.clone(opts), formatOpts).formatDateTime(this) : INVALID;
+-  }
++  }})
+   /**
+    * Returns an array of format "parts", meaning individual tokens along with metadata. This is allows callers to post-process individual sections of the formatted output.
+    * Defaults to the system's locale if no locale has been specified

--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
       "@metamask/snaps-cli>@metamask/snaps-utils>@metamask/permission-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>keccak": false,
       "@metamask/snaps-cli>@metamask/snaps-utils>@metamask/permission-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>secp256k1": false
     }
+  },
+  "resolutions": {
+    "luxon@^3.0.1": "patch:luxon@npm%3A3.1.0#./.yarn/patches/luxon-npm-3.1.0-16e2508500.patch"
   }
 }

--- a/packages/bip32/snap.manifest.json
+++ b/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "ShdHIfCWItGpXK4T9RlQPGgcRwMk/bV0Z3ZGVfL+D1w=",
+    "shasum": "kMT3MFqqScC9648WP3P02kqCdT2MzQy2ofVxjqexeBY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/bip44/snap.manifest.json
+++ b/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "Brf9T2suJzp9NfUBHj36R/2JlBxF1Ztu4Wu8cnY5LHw=",
+    "shasum": "jfAlv/8L1Oi2MWw6Kk436bL3Q2bBdcnRDTjNAb6Aa5I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/dialog/snap.manifest.json
+++ b/packages/dialog/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/test-snaps.git"
   },
   "source": {
-    "shasum": "bL5Vsu2tya2Je0EQxhXEb3Na9pDd68HYY8CUDrI9y4U=",
+    "shasum": "FhWjnUSaOHzjtjvB+jBB41Jg6c7lzfYBOxq27zl5BWE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13074,10 +13074,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"luxon@npm:^3.0.1":
+"luxon@npm:3.1.0":
   version: 3.1.0
   resolution: "luxon@npm:3.1.0"
   checksum: f8a850b759ba7a2e009d904c522ed7bc264bf4add57578f8948e52a0ed96b627b025b5aad8032295b570ae19fac41f0ffab91bdb128715fb0cc020798a7ba886
+  languageName: node
+  linkType: hard
+
+"luxon@patch:luxon@npm%3A3.1.0#./.yarn/patches/luxon-npm-3.1.0-16e2508500.patch::locator=root%40workspace%3A.":
+  version: 3.1.0
+  resolution: "luxon@patch:luxon@npm%3A3.1.0#./.yarn/patches/luxon-npm-3.1.0-16e2508500.patch::version=3.1.0&hash=ede6e5&locator=root%40workspace%3A."
+  checksum: 4ab1d73a2ef272d953048b6a59c10d3787a8690449c5c2784e99e9f8b3c2869dc1ea54e69f2e6f31b44acc5b9ef0e9d198af9a6680f45675eb015a60f727ebb8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Patch luxon since a few of the snaps have it included in their dependencies and luxon breaks under LavaMoat without the patch.