### PR TITLE
Update snap version to 5.1.1->5.1.2

### DIFF
--- a/packages/site/src/features/update-snap/Update.tsx
+++ b/packages/site/src/features/update-snap/Update.tsx
@@ -4,8 +4,8 @@ import { Result, Snap } from '../../components';
 import { useGetSnapsQuery, useInstallSnapMutation } from '../../api';
 
 const UPDATE_SNAP_ID = 'npm:@metamask/test-snap-bip32';
-const UPDATE_SNAP_OLD_VERSION = '5.0.0';
-const UPDATE_SNAP_NEW_VERSION = '5.0.1';
+const UPDATE_SNAP_OLD_VERSION = '5.1.1';
+const UPDATE_SNAP_NEW_VERSION = '5.1.2';
 
 export const Update: FunctionComponent = () => {
   const [installSnap, { isLoading }] = useInstallSnapMutation();


### PR DESCRIPTION
## Description

This pull request updates the `update snap` component version to `5.1.1->5.1.2` from `5.0.0->5.0.1`. The previous version
was outdated and thus replaced with the latest version. This update fixes compatibility with the latest `snaps-monorepo`.

## Changes

1. Update the version of the `update snap` component from `5.0.0->5.0.1` to `5.1.1->5.1.2`.